### PR TITLE
Fix type annotations for array inputs in signal functions

### DIFF
--- a/src/osipi/_aif.py
+++ b/src/osipi/_aif.py
@@ -1,18 +1,21 @@
 import numpy as np
+from numpy.typing import NDArray
 
 
-def aif_parker(t: np.ndarray, BAT: float = 0.0, Hct: float = 0.0) -> np.ndarray:
+def aif_parker(
+    t: NDArray[np.floating], BAT: np.floating = 0.0, Hct: np.floating = 0.0
+) -> NDArray[np.floating]:
     """AIF model as defined by Parker et al (2005)
 
     Args:
-        t (np.ndarray): array of time points in units of sec. [OSIPI code Q.GE1.004]
-        BAT (float, optional):
+        t (NDArray[np.floating]): array of time points in units of sec. [OSIPI code Q.GE1.004]
+        BAT (np.floating, optional):
             Time in seconds before the bolus arrives. Defaults to 0. [OSIPI code Q.BA1.001]
-        Hct (float, optional):
+        Hct (np.floating, optional):
             Hematocrit. Defaults to 0.0. [OSIPI code Q.PH1.012]
 
     Returns:
-        np.ndarray: Concentrations in mM for each time point in t.
+        NDArray[np.floating]: Concentrations in mM for each time point in t.
 
     See Also:
         `aif_georgiou`
@@ -68,7 +71,7 @@ def aif_parker(t: np.ndarray, BAT: float = 0.0, Hct: float = 0.0) -> np.ndarray:
     return pop_aif
 
 
-def aif_georgiou(t: np.ndarray, BAT: float = 0.0) -> np.ndarray:
+def aif_georgiou(t: NDArray[np.floating], BAT: np.floating = 0.0) -> NDArray[np.floating]:
     """AIF model as defined by Georgiou et al.
 
     Note:
@@ -77,12 +80,12 @@ def aif_georgiou(t: np.ndarray, BAT: float = 0.0) -> np.ndarray:
         so nobody ever has to write this function again!
 
     Args:
-        t (np.ndarray): array of time points in units of sec. [OSIPI code Q.GE1.004]
-        BAT (float, optional):
+        t (NDArray[np.floating]): array of time points in units of sec. [OSIPI code Q.GE1.004]
+        BAT (np.floating, optional):
             Time in seconds before the bolus arrives. Defaults to 0sec. [OSIPI code Q.BA1.001]
 
     Returns:
-        np.ndarray: Concentrations in mM for each time point in t.
+        NDArray[np.floating]: Concentrations in mM for each time point in t.
 
     See Also:
         `aif_parker`
@@ -122,7 +125,7 @@ def aif_georgiou(t: np.ndarray, BAT: float = 0.0) -> np.ndarray:
     raise NotImplementedError(msg)
 
 
-def aif_weinmann(t: np.ndarray, BAT: float = 0.0) -> np.ndarray:
+def aif_weinmann(t: NDArray[np.floating], BAT: np.floating = 0.0) -> NDArray[np.floating]:
     """AIF model as defined by Weinmann et al.
 
     Note:
@@ -131,12 +134,12 @@ def aif_weinmann(t: np.ndarray, BAT: float = 0.0) -> np.ndarray:
         so nobody ever has to write this function again!
 
     Args:
-        t (np.ndarray): array of time points in units of sec. [OSIPI code Q.GE1.004]
-        BAT (float, optional):
+        t (NDArray[np.floating]): array of time points in units of sec. [OSIPI code Q.GE1.004]
+        BAT (np.floating, optional):
             Time in seconds before the bolus arrives. Defaults to 0sec. [OSIPI code Q.BA1.001]
 
     Returns:
-        np.ndarray: Concentrations in mM for each time point in t.
+        NDArray[np.floating]: Concentrations in mM for each time point in t.
 
     See Also:
         `aif_parker`

--- a/src/osipi/_convolution.py
+++ b/src/osipi/_convolution.py
@@ -1,13 +1,19 @@
 import numpy as np
+from numpy.typing import NDArray
 
 
-def exp_conv(T: float, t: np.ndarray, a: np.ndarray) -> np.ndarray:
+def exp_conv(
+    T: np.floating, t: NDArray[np.floating], a: NDArray[np.floating]
+) -> NDArray[np.floating]:
     """Exponential convolution operation of (1/T)exp(-t/T) with a.
 
-    Args:     T (float): exponent in time units     t (np.ndarray): array of time points     a
-    (np.ndarray): array to be convolved with time exponential  Returns:     np.ndarray: convolved
-    array
+    Args:
+        T (np.floating): exponent in time units
+        t (NDArray[np.floating]): array of time points
+        a (NDArray[np.floating]): array to be convolved with time exponential
 
+    Returns:
+        NDArray[np.floating]: convolved array
     """
     if T == 0:
         return a

--- a/src/osipi/_electromagnetic_property.py
+++ b/src/osipi/_electromagnetic_property.py
@@ -3,8 +3,8 @@ from numpy.typing import NDArray
 
 
 def R1_to_C_linear_relaxivity(
-    R1: NDArray[np.float64], R10: np.float64, r1: np.float64
-) -> NDArray[np.float64]:
+    R1: NDArray[np.floating], R10: np.floating, r1: np.floating
+) -> NDArray[np.floating]:
     """
     Electromagnetic property inverse model:
     - longitudinal relaxation rate, linear with relaxivity
@@ -12,15 +12,15 @@ def R1_to_C_linear_relaxivity(
     Converts R1 to tissue concentration
 
     Args:
-        R1 (1D array of np.float64):
+        R1 (1D array of np.floating):
             Vector of longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.001]
-        R10 (np.float64):
+        R10 (np.floating):
             Native longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.002]
-        r1 (np.float64):
+        r1 (np.floating):
             Longitudinal relaxivity in units of /s/mM. [OSIPI code Q.EL1.015]
 
     Returns:
-        NDArray[np.float64]:
+        NDArray[np.floating]:
             Vector of indicator concentration in units of mM. [OSIPI code Q.IC1.001]
 
     References:
@@ -33,8 +33,8 @@ def R1_to_C_linear_relaxivity(
         - Adapted from equation given in lexicon
     """
     # Check R1 is a 1D array of floats
-    if not (isinstance(R1, np.ndarray) and R1.ndim == 1 and R1.dtype == np.float64):
-        raise TypeError("R1 must be a 1D NumPy array of np.float64")
+    if not (isinstance(R1, np.ndarray) and R1.ndim == 1 and np.issubdtype(R1.dtype, np.floating)):
+        raise TypeError("R1 must be a 1D NumPy array of np.floating")
     elif not (r1 >= 0):
         raise ValueError("r1 must be positive")
     return (R1 - R10) / r1  # C

--- a/src/osipi/_signal.py
+++ b/src/osipi/_signal.py
@@ -1,15 +1,16 @@
 import numpy as np
+from numpy.typing import NDArray
 
 
-def signal_linear(R1: np.float64, k: np.float64) -> np.float64:
+def signal_linear(R1: NDArray[np.float64], k: NDArray[np.float64]) -> NDArray[np.float64]:
     """Linear model for relationship between R1 and magnitude signal
 
     Args:
-        R1 (np.float64): longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.001]
-        k (np.float64): proportionality constant in a.u. S [OSIPI code Q.GE1.009]
+        R1 (NDArray[np.float64]): longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.001]
+        k (NDArray[np.float64]): proportionality constant in a.u. S [OSIPI code Q.GE1.009]
 
     Returns:
-        np.float64: magnitude signal in a.u. [OSIPI code Q.MS1.001]
+        NDArray[np.float64]: magnitude signal in a.u. [OSIPI code Q.MS1.001]
 
     References:
         - Lexicon url: https://osipi.github.io/OSIPI_CAPLEX/perfusionModels/#LinModel_SM2
@@ -21,17 +22,22 @@ def signal_linear(R1: np.float64, k: np.float64) -> np.float64:
     return k * R1  # S
 
 
-def signal_SPGR(R1: np.float64, S0: np.float64, TR: np.float64, a: np.float64) -> np.float64:
+def signal_SPGR(
+    R1: NDArray[np.float64],
+    S0: NDArray[np.float64],
+    TR: NDArray[np.float64],
+    a: NDArray[np.float64],
+) -> NDArray[np.float64]:
     """Steady-state signal for SPGR sequence.
 
     Args:
-        R1 (np.float64): longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.001]
-        S0 (np.float64): fully T1-relaxed signal in a.u. [OSIPI code Q.MS1.010]
-        TR (np.float64): repetition time in units of s. [OSIPI code Q.MS1.006]
-        a (np.float64): prescribed flip angle in units of deg. [OSIPI code Q.MS1.007]
+        R1 (NDArray[np.float64]): longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.001]
+        S0 (NDArray[np.float64]): fully T1-relaxed signal in a.u. [OSIPI code Q.MS1.010]
+        TR (NDArray[np.float64]): repetition time in units of s. [OSIPI code Q.MS1.006]
+        a (NDArray[np.float64]): prescribed flip angle in units of deg. [OSIPI code Q.MS1.007]
 
     Returns:
-        np.float64: magnitude signal in a.u. [OSIPI code Q.MS1.001]
+        NDArray[np.float64]: magnitude signal in a.u. [OSIPI code Q.MS1.001]
 
     References:
         - Lexicon url: https://osipi.github.io/OSIPI_CAPLEX/perfusionModels/#SPGR%20model

--- a/src/osipi/_signal.py
+++ b/src/osipi/_signal.py
@@ -2,16 +2,14 @@ import numpy as np
 from numpy.typing import NDArray
 
 
-def signal_linear(R1: NDArray[np.float64], k: NDArray[np.float64]) -> NDArray[np.float64]:
+# Use a more generic floating-point type annotation
+def signal_linear(R1: NDArray[np.floating], k: np.floating) -> NDArray[np.floating]:
     """Linear model for relationship between R1 and magnitude signal
-
     Args:
-        R1 (NDArray[np.float64]): longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.001]
-        k (NDArray[np.float64]): proportionality constant in a.u. S [OSIPI code Q.GE1.009]
-
+        R1 (NDArray[np.floating]): longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.001]
+        k (np.floating): proportionality constant in a.u. S [OSIPI code Q.GE1.009]
     Returns:
-        NDArray[np.float64]: magnitude signal in a.u. [OSIPI code Q.MS1.001]
-
+        NDArray[np.floating]: magnitude signal in a.u. [OSIPI code Q.MS1.001]
     References:
         - Lexicon url: https://osipi.github.io/OSIPI_CAPLEX/perfusionModels/#LinModel_SM2
         - Lexicon code: M.SM2.001
@@ -23,29 +21,25 @@ def signal_linear(R1: NDArray[np.float64], k: NDArray[np.float64]) -> NDArray[np
 
 
 def signal_SPGR(
-    R1: NDArray[np.float64],
-    S0: NDArray[np.float64],
-    TR: NDArray[np.float64],
-    a: NDArray[np.float64],
-) -> NDArray[np.float64]:
+    R1: NDArray[np.floating],
+    S0: NDArray[np.floating],
+    TR: np.floating,
+    a: np.floating,
+) -> NDArray[np.floating]:
     """Steady-state signal for SPGR sequence.
-
     Args:
-        R1 (NDArray[np.float64]): longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.001]
-        S0 (NDArray[np.float64]): fully T1-relaxed signal in a.u. [OSIPI code Q.MS1.010]
-        TR (NDArray[np.float64]): repetition time in units of s. [OSIPI code Q.MS1.006]
-        a (NDArray[np.float64]): prescribed flip angle in units of deg. [OSIPI code Q.MS1.007]
-
+        R1 (NDArray[np.floating]): longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.001]
+        S0 (NDArray[np.floating]): fully T1-relaxed signal in a.u. [OSIPI code Q.MS1.010]
+        TR (np.floating): repetition time in units of s. [OSIPI code Q.MS1.006]
+        a (np.floating): prescribed flip angle in units of deg. [OSIPI code Q.MS1.007]
     Returns:
-        NDArray[np.float64]: magnitude signal in a.u. [OSIPI code Q.MS1.001]
-
+        NDArray[np.floating]: magnitude signal in a.u. [OSIPI code Q.MS1.001]
     References:
         - Lexicon url: https://osipi.github.io/OSIPI_CAPLEX/perfusionModels/#SPGR%20model
         - Lexicon code: M.SM2.002
         - OSIPI name: Spoiled gradient recalled echo model
         - Adapted from equation given in the Lexicon and contribution from MJT_UoEdinburgh_UK
     """
-
     # calculate signal
     a_rad = a * np.pi / 180
     exp_TR_R1 = np.exp(-TR * R1)

--- a/src/osipi/_signal_to_concentration.py
+++ b/src/osipi/_signal_to_concentration.py
@@ -5,13 +5,13 @@ from ._electromagnetic_property import R1_to_C_linear_relaxivity
 
 
 def S_to_C_via_R1_SPGR(
-    S: NDArray[np.float64],
-    S_baseline: np.float64,
-    R10: np.float64,
-    TR: np.float64,
-    a: np.float64,
-    r1: np.float64,
-) -> NDArray[np.float64]:
+    S: NDArray[np.floating],
+    S_baseline: np.floating,
+    R10: np.floating,
+    TR: np.floating,
+    a: np.floating,
+    r1: np.floating,
+) -> NDArray[np.floating]:
     """
     Signal to concentration via
     electromagnetic property (SPGR, FXL, analytical, linear R1 relaxivity)
@@ -19,15 +19,15 @@ def S_to_C_via_R1_SPGR(
     Converts S -> R1 -> C
 
     Args:
-        S (1D array of np.float64): Vector of magnitude signals in a.u. [OSIPI code Q.MS1.001]
-        S_baseline (np.float64): Pre-contrast magnitude signal in a.u. [OSIPI code Q.MS1.001]
-        R10 (np.float64): Native longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.002]
-        TR (np.float64): Repetition time in units of s. [OSIPI code Q.MS1.006]
-        a (np.float64): Prescribed flip angle in units of deg. [OSIPI code Q.MS1.007]
-        r1 (np.float64): Longitudinal relaxivity in units of /s/mM. [OSIPI code Q.EL1.015]
+        S (1D array of np.floating): Vector of magnitude signals in a.u. [OSIPI code Q.MS1.001]
+        S_baseline (np.floating): Pre-contrast magnitude signal in a.u. [OSIPI code Q.MS1.001]
+        R10 (np.floating): Native longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.002]
+        TR (np.floating): Repetition time in units of s. [OSIPI code Q.MS1.006]
+        a (np.floating): Prescribed flip angle in units of deg. [OSIPI code Q.MS1.007]
+        r1 (np.floating): Longitudinal relaxivity in units of /s/mM. [OSIPI code Q.EL1.015]
 
     Returns:
-         NDArray[np.float64]:
+         NDArray[np.floating]:
             Vector of indicator total (across all compartments) indicator
             concentration in units of mM. [OSIPI code Q.IC1.001]
 
@@ -50,26 +50,26 @@ def S_to_C_via_R1_SPGR(
 
 
 def S_to_R1_SPGR(
-    S: NDArray[np.float64],
-    S_baseline: np.float64,
-    R10: np.float64,
-    TR: np.float64,
-    a: np.float64,
-) -> NDArray[np.float64]:
+    S: NDArray[np.floating],
+    S_baseline: np.floating,
+    R10: np.floating,
+    TR: np.floating,
+    a: np.floating,
+) -> NDArray[np.floating]:
     """
     Signal to electromagnetic property conversion (analytical, SPGR, FXL)
 
     Converts Signal to R1
 
     Args:
-        S (1D array of np.float64): Vector of magnitude signals in a.u. [OSIPI code Q.MS1.001]
-        S_baseline (np.float64): Pre-contrast magnitude signal in a.u. [OSIPI code Q.MS1.001]
-        R10 (np.float64): Native longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.002]
-        TR (np.float64): Repetition time in units of s. [OSIPI code Q.MS1.006]
-        a (np.float64): Prescribed flip angle in units of deg. [OSIPI code Q.MS1.007]
+        S (1D array of np.floating): Vector of magnitude signals in a.u. [OSIPI code Q.MS1.001]
+        S_baseline (np.floating): Pre-contrast magnitude signal in a.u. [OSIPI code Q.MS1.001]
+        R10 (np.floating): Native longitudinal relaxation rate in units of /s. [OSIPI code Q.EL1.002]
+        TR (np.floating): Repetition time in units of s. [OSIPI code Q.MS1.006]
+        a (np.floating): Prescribed flip angle in units of deg. [OSIPI code Q.MS1.007]
 
     Returns:
-        NDArray[np.float64]: Vector of R1 in units of /s. [OSIPI code Q.EL1.001]
+        NDArray[np.floating]: Vector of R1 in units of /s. [OSIPI code Q.EL1.001]
 
     References:
         - Lexicon URL: https://osipi.github.io/OSIPI_CAPLEX/perfusionProcesses/#
@@ -80,8 +80,8 @@ def S_to_R1_SPGR(
         - Adapted from contribution of LEK_UoEdinburgh_UK
     """
     # Check S is a 1D array of floats
-    if not (isinstance(S, np.ndarray) and S.ndim == 1 and S.dtype == np.float64):
-        raise TypeError("S must be a 1D NumPy array of np.float64")
+    if not (isinstance(S, np.ndarray) and S.ndim == 1 and np.issubdtype(S.dtype, np.floating)):
+        raise TypeError("S must be a 1D NumPy array of np.floating")
 
     a_rad = a * np.pi / 180
     # Estimate fully T1-relaxed signal S0 in units of a.u. [OSIPI code Q.MS1.010], then R1

--- a/src/osipi/_tissue.py
+++ b/src/osipi/_tissue.py
@@ -1,31 +1,32 @@
 import warnings
 
 import numpy as np
+from numpy.typing import NDArray
 from scipy.interpolate import interp1d
 
 from ._convolution import exp_conv
 
 
 def tofts(
-    t: np.ndarray,
-    ca: np.ndarray,
-    Ktrans: float,
-    ve: float,
-    Ta: float = 30.0,
+    t: NDArray[np.floating],
+    ca: NDArray[np.floating],
+    Ktrans: np.floating,
+    ve: np.floating,
+    Ta: np.floating = 30.0,
     discretization_method: str = "conv",
-) -> np.ndarray:
+) -> NDArray[np.floating]:
     """Tofts model as defined by Tofts and Kermode (1991)
 
     Args:
-        t (np.ndarray): array of time points in units of sec. [OSIPI code Q.GE1.004]
-        ca (np.ndarray):
+        t (NDArray[np.floating]): array of time points in units of sec. [OSIPI code Q.GE1.004]
+        ca (NDArray[np.floating]):
             Arterial concentrations in mM for each time point in t. [OSIPI code Q.IC1.001]
-        Ktrans (float):
+        Ktrans (np.floating):
             Volume transfer constant in units of 1/min. [OSIPI code Q.PH1.008]
-        ve (float):
+        ve (np.floating):
             Relative volume fraction of the extracellular
             extravascular compartment (e). [OSIPI code Q.PH1.001.[e]]
-        Ta (float, optional):
+        Ta (np.floating, optional):
             Arterial delay time,
             i.e., difference in onset time between tissue curve and AIF in units of sec. Defaults to 30 seconds. [OSIPI code Q.PH1.007]
         discretization_method (str, optional): Defines the discretization method. Options include
@@ -36,7 +37,7 @@ def tofts(
 
 
     Returns:
-        np.ndarray: Tissue concentrations in mM for each time point in t.
+        NDArray[np.floating]: Tissue concentrations in mM for each time point in t.
 
     See Also:
         `extended_tofts`
@@ -166,29 +167,29 @@ def tofts(
 
 
 def extended_tofts(
-    t: np.ndarray,
-    ca: np.ndarray,
-    Ktrans: float,
-    ve: float,
-    vp: float,
-    Ta: float = 30.0,
+    t: NDArray[np.floating],
+    ca: NDArray[np.floating],
+    Ktrans: np.floating,
+    ve: np.floating,
+    vp: np.floating,
+    Ta: np.floating = 30.0,
     discretization_method: str = "conv",
-) -> np.ndarray:
+) -> NDArray[np.floating]:
     """Extended tofts model as defined by Tofts (1997)
 
     Args:
-        t (np.ndarray):
+        t (NDArray[np.floating]):
             array of time points in units of sec. [OSIPI code Q.GE1.004]
-        ca (np.ndarray):
+        ca (NDArray[np.floating]):
             Arterial concentrations in mM for each time point in t. [OSIPI code Q.IC1.001]
-        Ktrans (float):
+        Ktrans (np.floating):
             Volume transfer constant in units of 1/min. [OSIPI code Q.PH1.008]
-        ve (float):
+        ve (np.floating):
             Relative volume fraction of the extracellular
             extravascular compartment (e). [OSIPI code Q.PH1.001.[e]]
-        vp (float):
+        vp (np.floating):
             Relative volyme fraction of the plasma compartment (p). [OSIPI code Q.PH1.001.[p]]
-        Ta (float, optional):
+        Ta (np.floating, optional):
             Arterial delay time, i.e., difference in onset time
             between tissue curve and AIF in units of sec.
             Defaults to 30 seconds. [OSIPI code Q.PH1.007]
@@ -201,7 +202,7 @@ def extended_tofts(
 
 
     Returns:
-        np.ndarray: Tissue concentrations in mM for each time point in t.
+        NDArray[np.floating]: Tissue concentrations in mM for each time point in t.
 
     See Also:
         `tofts`


### PR DESCRIPTION
This PR fixes the type annotations in `signal_linear()` and `signal_SPGR()` functions to properly reflect that they handle both scalar and array inputs.

The fix uses `NDArray[np.float64]` to annotate the parameters and return values, which correctly handles both NumPy scalars (0D arrays) and multi-dimensional arrays.

Fixes #61