### PR TITLE
Readme file updating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/site
 docs/generated
 site
 src/osipi.egg-info
+venv

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ We use poetry to manage the dependencies for this project.
    
      If pipx is not already installed, you can follow any of the options in the [pipx installation guide](https://pipx.pypa.io/stable/installation/)
     
-    ```bash
-      pipx install poetry
+     ```bash
+        pipx install poetry
      ```
   
    For more information on installing Poetry, see the [official documentation](https://python-poetry.org/docs/)

--- a/README.md
+++ b/README.md
@@ -53,31 +53,30 @@ We use poetry to manage the dependencies for this project.
 
 ### Using Poetry
 
-1. If you don't have Poetry installed 
+1. If you don't have Poetry installed
 
      Option 1: install via pipx:
 
       if pipx is not already installed, you can follow any of the options in the [pipx installation guide](https://pipx.pypa.io/stable/installation/)
-    
+
       ```bash
       pipx install poetry
       ```
- 
 
      Option 2: if you're using a Unix-based system, you can install it using the following command:
 
      ```bash
      curl -sSL https://install.python-poetry.org | python3 -
      ```
-  
+
      Option 3: you can install it using pip:
-   
+
      ```bash
      pip install poetry
      ```
-   
- 
-  
+
+
+
    For more information on installing Poetry, see the [official documentation](https://python-poetry.org/docs/)
 
 2. Clone the repository to your local machine.

--- a/README.md
+++ b/README.md
@@ -53,18 +53,26 @@ We use poetry to manage the dependencies for this project.
 
 ### Using Poetry
 
-1. If you don't have Poetry installed, you can install it using pip:
-
+1. If you don't have Poetry installed 
+   option 1: you can install it using pip:
+   
    ```bash
    pip install poetry
    ```
 
-   Or, if you're using a Unix-based system, you can install it using the following command:
+  option 2: if you're using a Unix-based system, you can install it using the following command:
 
    ```bash
    curl -sSL https://install.python-poetry.org | python3 -
    ```
 
+  Option 3: Install via pipx (If Other Methods Fail):
+  If pipx is not already installed, you can follow any of the options in the [pipx installation guide](https://pipx.pypa.io/stable/installation/)
+  
+  ```bash
+    pipx install poetry
+   ```
+  
    For more information on installing Poetry, see the [official documentation](https://python-poetry.org/docs/)
 
 2. Clone the repository to your local machine.

--- a/README.md
+++ b/README.md
@@ -54,36 +54,38 @@ We use poetry to manage the dependencies for this project.
 ### Using Poetry
 
 1. If you don't have Poetry installed 
-   option 1: you can install it using pip:
-   
-   ```bash
-   pip install poetry
-   ```
 
-  option 2: if you're using a Unix-based system, you can install it using the following command:
+     option 1: you can install it using pip:
+     
+     ```bash
+     pip install poetry
+     ```
 
-   ```bash
-   curl -sSL https://install.python-poetry.org | python3 -
-   ```
+     option 2: if you're using a Unix-based system, you can install it using the following command:
 
-  Option 3: Install via pipx (If Other Methods Fail):
-  If pipx is not already installed, you can follow any of the options in the [pipx installation guide](https://pipx.pypa.io/stable/installation/)
+     ```bash
+     curl -sSL https://install.python-poetry.org | python3 -
+     ```
   
-  ```bash
-    pipx install poetry
-   ```
+    Option 3: Install via pipx (If Other Methods Fail):
+   
+    If pipx is not already installed, you can follow any of the options in the [pipx installation guide](https://pipx.pypa.io/stable/installation/)
+    
+    ```bash
+      pipx install poetry
+     ```
   
    For more information on installing Poetry, see the [official documentation](https://python-poetry.org/docs/)
 
-2. Clone the repository to your local machine.
-3. Navigate to the project directory.
-4. Install the project dependencies with Poetry:
+3. Clone the repository to your local machine.
+4. Navigate to the project directory.
+5. Install the project dependencies with Poetry:
 
    ```bash
    poetry install
    ```
 
-5. Activate the Poetry environment:
+6. Activate the Poetry environment:
 
    ```bash
    poetry shell

--- a/README.md
+++ b/README.md
@@ -55,21 +55,21 @@ We use poetry to manage the dependencies for this project.
 
 1. If you don't have Poetry installed 
 
-     option 1: you can install it using pip:
+     Option 1: you can install it using pip:
      
      ```bash
      pip install poetry
      ```
 
-     option 2: if you're using a Unix-based system, you can install it using the following command:
+     Option 2: if you're using a Unix-based system, you can install it using the following command:
 
      ```bash
      curl -sSL https://install.python-poetry.org | python3 -
      ```
   
-    Option 3: Install via pipx (If Other Methods Fail):
+     Option 3: Install via pipx (If Other Methods Fail):
    
-    If pipx is not already installed, you can follow any of the options in the [pipx installation guide](https://pipx.pypa.io/stable/installation/)
+     If pipx is not already installed, you can follow any of the options in the [pipx installation guide](https://pipx.pypa.io/stable/installation/)
     
     ```bash
       pipx install poetry

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ We use poetry to manage the dependencies for this project.
 
 1. If you don't have Poetry installed 
 
-     Option 1: Install via pipx:
+     Option 1: install via pipx:
 
-      If pipx is not already installed, you can follow any of the options in the [pipx installation guide](https://pipx.pypa.io/stable/installation/)
+      if pipx is not already installed, you can follow any of the options in the [pipx installation guide](https://pipx.pypa.io/stable/installation/)
     
       ```bash
       pipx install poetry

--- a/README.md
+++ b/README.md
@@ -55,11 +55,14 @@ We use poetry to manage the dependencies for this project.
 
 1. If you don't have Poetry installed 
 
-     Option 1: you can install it using pip:
-     
-     ```bash
-     pip install poetry
-     ```
+     Option 1: Install via pipx:
+
+      If pipx is not already installed, you can follow any of the options in the [pipx installation guide](https://pipx.pypa.io/stable/installation/)
+    
+      ```bash
+      pipx install poetry
+      ```
+ 
 
      Option 2: if you're using a Unix-based system, you can install it using the following command:
 
@@ -67,25 +70,25 @@ We use poetry to manage the dependencies for this project.
      curl -sSL https://install.python-poetry.org | python3 -
      ```
   
-     Option 3: Install via pipx (If Other Methods Fail):
+     Option 3: you can install it using pip:
    
-     If pipx is not already installed, you can follow any of the options in the [pipx installation guide](https://pipx.pypa.io/stable/installation/)
-    
      ```bash
-        pipx install poetry
+     pip install poetry
      ```
+   
+ 
   
    For more information on installing Poetry, see the [official documentation](https://python-poetry.org/docs/)
 
-3. Clone the repository to your local machine.
-4. Navigate to the project directory.
-5. Install the project dependencies with Poetry:
+2. Clone the repository to your local machine.
+3. Navigate to the project directory.
+4. Install the project dependencies with Poetry:
 
    ```bash
    poetry install
    ```
 
-6. Activate the Poetry environment:
+5. Activate the Poetry environment:
 
    ```bash
    poetry shell


### PR DESCRIPTION
This PR updates the README to include multiple installation methods for Poetry, ensuring users have alternative approaches if one method fails. Specifically, it:
divide instructions into options Poetry using pip, official install script, and pipx.
Includes a direct reference to the pipx installation guide for further details.
Ensures Windows and Unix-based system users have clear, separate commands.

Why This Change?
Provides multiple ways to install Poetry, reducing installation issues.
Improves documentation by linking to the official pipx guide.