### PR TITLE
fix: replace deprecated `np.trapz` with `np.trapezoid` for numpy 2.x compatibility

### DIFF
--- a/tests/test_tissue.py
+++ b/tests/test_tissue.py
@@ -45,8 +45,8 @@ def test_tissue_tofts():
     ca = osipi.aif_parker(t)
     ct_conv = osipi.tofts(t, ca, Ktrans=0.6, ve=0.2)
     ct_exp = osipi.tofts(t, ca, Ktrans=0.6, ve=0.2, discretization_method="exp")
-    assert math.isclose(np.trapz(ct_conv, t) / np.trapz(ca, t), 0.2, abs_tol=1e-1)
-    assert math.isclose(np.trapz(ct_exp, t) / np.trapz(ca, t), 0.2, abs_tol=1e-1)
+    assert math.isclose(np.trapezoid(ct_conv, t) / np.trapezoid(ca, t), 0.2, abs_tol=1e-1)
+    assert math.isclose(np.trapezoid(ct_exp, t) / np.trapezoid(ca, t), 0.2, abs_tol=1e-1)
 
     # 6. Test specific use cases
     t = np.arange(0, 6 * 60, 1)
@@ -102,11 +102,11 @@ def test_tissue_extended_tofts():
     ct_conv = osipi.extended_tofts(t, ca, Ktrans=0.6, ve=0.2, vp=0.3)
     ct_exp = osipi.extended_tofts(t, ca, Ktrans=0.6, ve=0.2, vp=0.3, discretization_method="exp")
     assert math.isclose(
-        np.trapz(ct_conv, t) / np.trapz(ca, t),
+        np.trapezoid(ct_conv, t) / np.trapezoid(ca, t),
         0.2 + 0.3,
         abs_tol=1e-1,
     )
-    assert math.isclose(np.trapz(ct_exp, t) / np.trapz(ca, t), 0.2 + 0.3, abs_tol=1e-1)
+    assert math.isclose(np.trapezoid(ct_exp, t) / np.trapezoid(ca, t), 0.2 + 0.3, abs_tol=1e-1)
 
     # 6. Test specific use cases
     t = np.arange(0, 6 * 60, 1)


### PR DESCRIPTION
@ltorres6 
`numpy.trapz()` was deprecated in numpy 1.25 and removed in numpy 2.0, breaking 2 out of 10 tests in the test suite. This PR replaces all `np.trapz()` calls in `test_tissue.py` with `np.trapezoid()`, which is the official numpy 2.x replacement.

### Fix
Replaced 8 occurrences of `np.trapz(` with `np.trapezoid(` in `tests/test_tissue.py`.

### File Changed
`tests/test_tissue.py`

```diff
-    assert math.isclose(np.trapz(ct_conv, t) / np.trapz(ca, t), 0.2, abs_tol=1e-1)
-    assert math.isclose(np.trapz(ct_exp, t) / np.trapz(ca, t), 0.2, abs_tol=1e-1)
+    assert math.isclose(np.trapezoid(ct_conv, t) / np.trapezoid(ca, t), 0.2, abs_tol=1e-1)
+    assert math.isclose(np.trapezoid(ct_exp, t) / np.trapezoid(ca, t), 0.2, abs_tol=1e-1)
```

```diff
     assert math.isclose(
-        np.trapz(ct_conv, t) / np.trapz(ca, t),
+        np.trapezoid(ct_conv, t) / np.trapezoid(ca, t),
         0.2 + 0.3,
         abs_tol=1e-1,
     )
-    assert math.isclose(np.trapz(ct_exp, t) / np.trapz(ca, t), 0.2 + 0.3, abs_tol=1e-1)
+    assert math.isclose(np.trapezoid(ct_exp, t) / np.trapezoid(ca, t), 0.2 + 0.3, abs_tol=1e-1)
```

---

## Python Test Suite Results

### `main` branch (before fix)
```
tests/test_aif.py::test_aif_parker             PASSED
tests/test_aif.py::test_aif_georgiou           PASSED
tests/test_aif.py::test_aif_weinmann           PASSED
tests/test_signal.py::test_signal_linear       PASSED
tests/test_signal.py::test_signal_SPGR         PASSED
tests/test_signal_to_concentration.py::test_S_to_C_via_R1_SPGR         PASSED
tests/test_signal_to_concentration.py::test_S_to_R1_SPGR               PASSED
tests/test_signal_to_concentration.py::test_R1_to_C_linear_relaxivity  PASSED
tests/test_tissue.py::test_tissue_tofts           FAILED  ❌
tests/test_tissue.py::test_tissue_extended_tofts  FAILED  ❌

Result: 2 failed, 8 passed
Error: AttributeError: module 'numpy' has no attribute 'trapz'
```

### `fix/bug-01-numpy-trapz` branch (after fix)
```
tests/test_aif.py::test_aif_parker             PASSED
tests/test_aif.py::test_aif_georgiou           PASSED
tests/test_aif.py::test_aif_weinmann           PASSED
tests/test_signal.py::test_signal_linear       PASSED
tests/test_signal.py::test_signal_SPGR         PASSED
tests/test_signal_to_concentration.py::test_S_to_C_via_R1_SPGR         PASSED
tests/test_signal_to_concentration.py::test_S_to_R1_SPGR               PASSED
tests/test_signal_to_concentration.py::test_R1_to_C_linear_relaxivity  PASSED
tests/test_tissue.py::test_tissue_tofts           PASSED  ✅
tests/test_tissue.py::test_tissue_extended_tofts  PASSED  ✅

Result: 10 passed, 0 failed ✅
```
Resolves #77 