### PR TITLE
fix: synchronize `[tool.poetry].version` to `0.1.2` to match `[project].version`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ line-length = 100
 
 [tool.poetry]
 name = "osipi"
-version = "0.1.0"
+version = "0.1.2"
 description = "The authorative python package for perfusion MRI"
 authors = [ "Luis Torres <luistorres@flywheel.io>", "Steven Sourbron <s.sourborn@sheffield.ac.uk>",]
 readme = "README.md"


### PR DESCRIPTION
`[project].version` is `0.1.2` but `[tool.poetry].version` is `0.1.0`. Since `handle_versioning.py` only reads/writes the poetry version, each release bump widens the gap. This PR synchronizes them.

### Fix
Changed `[tool.poetry].version` from `"0.1.0"` to `"0.1.2"`.

### File Changed
`pyproject.toml`

```diff
 [tool.poetry]
 name = "osipi"
-version = "0.1.0"
+version = "0.1.2"
 description = "The authorative python package for perfusion MRI"
```

---

## Library Integration Output Comparison

### `main` branch (before fix)
```
  [project].version      = 0.1.2
  [tool.poetry].version  = 0.1.0
  Match:                   NO — MISMATCH

>> VERDICT: Bug is PRESENT. Versions are out of sync: 0.1.2 vs 0.1.0.
```

### `fix/bug-03-version-mismatch` branch (after fix)
```
  [project].version      = 0.1.2
  [tool.poetry].version  = 0.1.2
  Match:                   YES

>> VERDICT: Bug is FIXED. Both version fields are synchronized.
```

---

## Python Test Suite Results

### `main` branch (before fix)

| # | Test | Status | Detail |
|---|------|--------|--------|
| 1 | Both version fields exist | PASS | |
| 2 | Versions match | FAIL | 0.1.2 vs 0.1.0 |
| 3 | handle_versioning.py reads poetry version | PASS | |
| 4 | Release uses handle_versioning.py | PASS | |

**Summary: PASSED=3 FAILED=1**

### `fix/bug-03-version-mismatch` branch (after fix)

| # | Test | Status | Detail |
|---|------|--------|--------|
| 1 | Both version fields exist | PASS | |
| 2 | Versions match | PASS | |
| 3 | handle_versioning.py reads poetry version | PASS | |
| 4 | Release uses handle_versioning.py | PASS | |

**Summary: PASSED=4 FAILED=0 ✅**

Resolves #80 