### PR TITLE
fix: correct --cov target from `dbdicom` to `osipi` in pytest CI workflow

### DIFF
--- a/.github/workflows/pytest-actions.yaml
+++ b/.github/workflows/pytest-actions.yaml
@@ -49,7 +49,7 @@ jobs:
         run: poetry install
 
       - name: Test with pytest
-        run: poetry run pytest --junitxml=junit/test-results.xml --cov=dbdicom tests/
+        run: poetry run pytest --junitxml=junit/test-results.xml --cov=osipi tests/
 
       - name: Upload coverage to Codecov
         if: runner.os == 'Windows'


### PR DESCRIPTION
The CI pytest workflow uses `--cov=dbdicom` instead of `--cov=osipi`, meaning code coverage has never been measured for this project. `dbdicom` is a completely different, unrelated project — this is a copy-paste artifact.

### Fix
Changed `--cov=dbdicom` to `--cov=osipi` on line 52 of `.github/workflows/pytest-actions.yaml`.

### File Changed
`.github/workflows/pytest-actions.yaml`

```diff
       - name: Test with pytest
-        run: poetry run pytest --junitxml=junit/test-results.xml --cov=dbdicom tests/
+        run: poetry run pytest --junitxml=junit/test-results.xml --cov=osipi tests/
```

---

## Library Integration Output Comparison

### `main` branch (before fix)
```
  Coverage target found: --cov=dbdicom
  Expected target:       --cov=osipi

>> VERDICT: Bug is PRESENT. Coverage measures 'dbdicom' instead of 'osipi'.
```

### `fix/bug-02-ci-coverage-target` branch (after fix)
```
  Coverage target found: --cov=osipi
  Expected target:       --cov=osipi

>> VERDICT: Bug is FIXED. Coverage target is correctly set to 'osipi'.
```

---

## Python Test Suite Results

### `main` branch (before fix)

| # | Test | Status | Detail |
|---|------|--------|--------|
| 1 | Workflow file contains pytest command | PASS | |
| 2 | --cov flag references 'osipi' | FAIL | Found '--cov=dbdicom' |
| 3 | --cov does NOT reference 'dbdicom' | FAIL | Found '--cov=dbdicom' |
| 4 | 'dbdicom' is NOT a project dependency | PASS | |

**Summary: PASSED=2 FAILED=2**

### `fix/bug-02-ci-coverage-target` branch (after fix)

| # | Test | Status | Detail |
|---|------|--------|--------|
| 1 | Workflow file contains pytest command | PASS | |
| 2 | --cov flag references 'osipi' | PASS | |
| 3 | --cov does NOT reference 'dbdicom' | PASS | |
| 4 | 'dbdicom' is NOT a project dependency | PASS | |

**Summary: PASSED=4 FAILED=0 ✅**

Resolves #79 