### PR TITLE
fix: compute IVIM quality mask after D*/D swap

### DIFF
--- a/osipy/ivim/fitting/estimators.py
+++ b/osipy/ivim/fitting/estimators.py
@@ -352,18 +352,8 @@ def _apply_ivim_quality_and_swap(param_maps: dict[str, ParameterMap]) -> None:
     if "D*" in param_maps:
         ds_vals = param_maps["D*"].values
 
-        # Domain quality mask
-        quality = (
-            fitter_qmask
-            & (d_vals > 0)
-            & (d_vals < 5e-3)
-            & (ds_vals > d_vals)
-            & (ds_vals < 100e-3)
-            & (f_vals >= 0)
-            & (f_vals <= 0.7)
-        )
-
-        # Ensure D* > D (swap if needed)
+        # Ensure D* > D (swap if needed) — must happen BEFORE quality check
+        # so the quality mask reflects post-swap values
         swap = d_vals > ds_vals
         d_swapped = xp.where(swap, ds_vals, d_vals)
         ds_swapped = xp.where(swap, d_vals, ds_vals)
@@ -371,6 +361,17 @@ def _apply_ivim_quality_and_swap(param_maps: dict[str, ParameterMap]) -> None:
         # Update values in-place via array views
         d_map.values[...] = d_swapped
         param_maps["D*"].values[...] = ds_swapped
+
+        # Domain quality mask (computed on post-swap values)
+        quality = (
+            fitter_qmask
+            & (d_swapped > 0)
+            & (d_swapped < 5e-3)
+            & (ds_swapped > d_swapped)
+            & (ds_swapped < 100e-3)
+            & (f_vals >= 0)
+            & (f_vals <= 0.7)
+        )
     else:
         quality = (
             fitter_qmask

--- a/tests/unit/ivim/test_ivim.py
+++ b/tests/unit/ivim/test_ivim.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+from osipy.common.parameter_map import ParameterMap
 from osipy.ivim import (
     FittingMethod,
     IVIMBiexponentialModel,
@@ -12,6 +13,7 @@ from osipy.ivim import (
     IVIMSimplifiedModel,
     fit_ivim,
 )
+from osipy.ivim.fitting.estimators import _apply_ivim_quality_and_swap
 
 
 def generate_ivim_signal(
@@ -208,3 +210,74 @@ class TestIVIMFitParams:
         )
         assert params.method == FittingMethod.FULL
         assert params.b_threshold == 150.0
+
+
+class TestQualityMaskSwapInteraction:
+    """Regression tests for D*/D swap + quality mask ordering (issue #107)."""
+
+    @staticmethod
+    def _make_param_maps(
+        d_vals: np.ndarray, ds_vals: np.ndarray, f_vals: np.ndarray
+    ) -> dict[str, ParameterMap]:
+        affine = np.eye(4)
+        shape = d_vals.shape
+        qmask = np.ones(shape, dtype=bool)
+        return {
+            "D": ParameterMap(
+                name="D", symbol="D", units="mm²/s",
+                values=d_vals.copy(), affine=affine, quality_mask=qmask.copy(),
+            ),
+            "D*": ParameterMap(
+                name="D*", symbol="D*", units="mm²/s",
+                values=ds_vals.copy(), affine=affine, quality_mask=qmask.copy(),
+            ),
+            "f": ParameterMap(
+                name="f", symbol="f", units="",
+                values=f_vals.copy(), affine=affine, quality_mask=qmask.copy(),
+            ),
+        }
+
+    def test_swapped_voxel_passes_quality(self) -> None:
+        """Voxel with D > D* should pass quality after swap (regression #107)."""
+        # Optimizer returned D=2e-3, D*=1e-3 (needs swap)
+        # After swap: D=1e-3, D*=2e-3 — both within valid bounds
+        param_maps = self._make_param_maps(
+            d_vals=np.array([[[2e-3]]]),
+            ds_vals=np.array([[[1e-3]]]),
+            f_vals=np.array([[[0.15]]]),
+        )
+
+        _apply_ivim_quality_and_swap(param_maps)
+
+        # Values should be swapped
+        assert param_maps["D"].values[0, 0, 0] == pytest.approx(1e-3)
+        assert param_maps["D*"].values[0, 0, 0] == pytest.approx(2e-3)
+        # Quality mask must be True — this voxel is valid post-swap
+        assert param_maps["D"].quality_mask[0, 0, 0]
+
+    def test_already_ordered_voxel_unaffected(self) -> None:
+        """Voxel with D < D* should pass quality without swap."""
+        param_maps = self._make_param_maps(
+            d_vals=np.array([[[1e-3]]]),
+            ds_vals=np.array([[[10e-3]]]),
+            f_vals=np.array([[[0.1]]]),
+        )
+
+        _apply_ivim_quality_and_swap(param_maps)
+
+        assert param_maps["D"].values[0, 0, 0] == pytest.approx(1e-3)
+        assert param_maps["D*"].values[0, 0, 0] == pytest.approx(10e-3)
+        assert param_maps["D"].quality_mask[0, 0, 0]
+
+    def test_out_of_bounds_rejected_even_after_swap(self) -> None:
+        """Voxel that fails domain bounds should be rejected regardless of swap."""
+        # D=200e-3 far exceeds the 5e-3 upper bound even after swap
+        param_maps = self._make_param_maps(
+            d_vals=np.array([[[200e-3]]]),
+            ds_vals=np.array([[[1e-3]]]),
+            f_vals=np.array([[[0.1]]]),
+        )
+
+        _apply_ivim_quality_and_swap(param_maps)
+
+        assert not param_maps["D"].quality_mask[0, 0, 0]


### PR DESCRIPTION
## Summary

Fixes #107 — IVIM quality mask was computed **before** the D\*/D swap, causing voxels that needed swapping to be incorrectly flagged as bad quality.

## Problem

In `_apply_ivim_quality_and_swap()`, the domain quality mask included the check `ds_vals > d_vals`. When the optimizer returned D > D\* (a common occurrence since the labels are interchangeable), this check evaluated to `False` — marking the voxel as bad quality — even though the very next code block would swap the values into the correct order.

**Result:** valid voxels were silently zeroed out by the quality mask, reducing usable perfusion-fraction map coverage.

## Fix

Moved the D\*/D swap **before** the quality mask computation. The domain checks (`D* > D`, `D < 5e-3`, etc.) now operate on **post-swap** values, so voxels that only needed a label swap are no longer falsely rejected.

## Changes

- `osipy/ivim/fitting/estimators.py`: Reordered swap and quality-mask blocks in `_apply_ivim_quality_and_swap()`
  - Swap block now executes first
  - Quality mask uses `d_swapped` / `ds_swapped` instead of `d_vals` / `ds_vals`

## Testing

- All 36 existing IVIM unit tests pass (`pytest tests/unit/ivim/ -v`)
- `ruff check .` — all checks passed
- No new dependencies introduced
