### PR TITLE
fix(ivim): evaluate quality mask after D*/D swap

### DIFF
--- a/osipy/ivim/fitting/estimators.py
+++ b/osipy/ivim/fitting/estimators.py
@@ -352,18 +352,8 @@ def _apply_ivim_quality_and_swap(param_maps: dict[str, ParameterMap]) -> None:
     if "D*" in param_maps:
         ds_vals = param_maps["D*"].values
 
-        # Domain quality mask
-        quality = (
-            fitter_qmask
-            & (d_vals > 0)
-            & (d_vals < 5e-3)
-            & (ds_vals > d_vals)
-            & (ds_vals < 100e-3)
-            & (f_vals >= 0)
-            & (f_vals <= 0.7)
-        )
-
-        # Ensure D* > D (swap if needed)
+        # Ensure D* > D (swap if needed) -- must happen BEFORE quality mask
+        # so the mask is evaluated on physiologically valid (post-swap) values.
         swap = d_vals > ds_vals
         d_swapped = xp.where(swap, ds_vals, d_vals)
         ds_swapped = xp.where(swap, d_vals, ds_vals)
@@ -371,6 +361,17 @@ def _apply_ivim_quality_and_swap(param_maps: dict[str, ParameterMap]) -> None:
         # Update values in-place via array views
         d_map.values[...] = d_swapped
         param_maps["D*"].values[...] = ds_swapped
+
+        # Domain quality mask -- evaluated on post-swap values
+        quality = (
+            fitter_qmask
+            & (d_swapped > 0)
+            & (d_swapped < 5e-3)
+            & (ds_swapped > d_swapped)
+            & (ds_swapped < 100e-3)
+            & (f_vals >= 0)
+            & (f_vals <= 0.7)
+        )
     else:
         quality = (
             fitter_qmask


### PR DESCRIPTION
Fixes #107.

In [_apply_ivim_quality_and_swap()](cci:1://file:///c:/my%20files/GESOC_2026/osipy/osipy/ivim/fitting/estimators.py:328:0-386:44), the domain quality mask was computed **before** the D*/D swap. Because one of the quality checks is `ds_vals > d_vals`, any voxel where the optimizer returned D > D* was immediately flagged as bad quality — even though the swap block immediately following would have corrected those values.

## Fix

Reordered the operations: swap happens first, then the quality mask is evaluated on the post-swap (physiologically valid) values. Voxels that only needed a label-swap are no longer incorrectly zeroed out in the perfusion-fraction map.

## Reproduction

```python
import numpy as np
from osipy.common.parameter_map import ParameterMap

d_map = ParameterMap(values=np.array([2e-3]), quality_mask=np.ones(1, dtype=bool))
ds_map = ParameterMap(values=np.array([1e-3]), quality_mask=np.ones(1, dtype=bool))
f_map = ParameterMap(values=np.array([0.15]), quality_mask=np.ones(1, dtype=bool))
param_maps = {"D": d_map, "D*": ds_map, "f": f_map}
# Before fix: quality_mask becomes False (voxel falsely rejected)
# After fix: quality_mask remains True (voxel correctly accepted after swap)
