### PR TITLE
feat(asl): add qc sub-module with SNR metric

### DIFF
--- a/osipy/asl/qc/__init__.py
+++ b/osipy/asl/qc/__init__.py
@@ -1,0 +1,27 @@
+"""ASL Quality Control sub-module.
+
+Provides tools for assessing the quality of ASL perfusion MRI acquisitions,
+following the OSIPI ASL Lexicon and ISMRM Perfusion Study Group guidelines.
+
+Included metrics
+----------------
+- **SNR**: Signal-to-Noise Ratio of the CBF map (``compute_snr``).
+
+References
+----------
+.. [1] Alsop DC et al. (2015). Recommended implementation of arterial
+   spin-labeled perfusion MRI for clinical applications.
+   Magn Reson Med 73(1):102-116. doi:10.1002/mrm.25197
+"""
+
+from osipy.asl.qc.snr import (
+    ASLSNRParams,
+    ASLSNRResult,
+    compute_snr,
+)
+
+__all__ = [
+    "ASLSNRParams",
+    "ASLSNRResult",
+    "compute_snr",
+]

--- a/osipy/asl/qc/snr.py
+++ b/osipy/asl/qc/snr.py
@@ -1,0 +1,239 @@
+"""ASL Quality Control — Signal-to-Noise Ratio (SNR) metric.
+
+This module computes voxel-wise and region-wise SNR for ASL cerebral blood
+flow (CBF) maps. SNR is a fundamental quality indicator for ASL acquisitions:
+low SNR may indicate motion artefacts, insufficient averaging, or hardware
+issues.
+
+The SNR is defined as the mean signal in a region of interest divided by the
+standard deviation of signal in a noise-only region:
+
+    SNR = mean(signal_ROI) / std(noise_ROI)
+
+A voxel-wise variant divides each voxel's value by the global noise estimate,
+producing an SNR map with the same shape as the input.
+
+References
+----------
+.. [1] Alsop DC et al. (2015). Recommended implementation of arterial
+   spin-labeled perfusion MRI for clinical applications: A consensus of the
+   ISMRM Perfusion Study Group and the European Consortium for ASL in
+   Dementia. Magn Reson Med 73(1):102-116. doi:10.1002/mrm.25197
+.. [2] Xie J et al. (2023). Quality control for ASL MRI in multi-centre
+   studies. NeuroImage 274:120136. doi:10.1016/j.neuroimage.2023.120136
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from osipy.common.backend.array_module import get_array_module
+from osipy.common.exceptions import DataValidationError
+from osipy.common.parameter_map import ParameterMap
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ASLSNRParams:
+    """Parameters for ASL SNR computation.
+
+    Attributes
+    ----------
+    min_noise_voxels : int
+        Minimum number of noise-region voxels required for a reliable
+        noise estimate. Raises ``DataValidationError`` if fewer are found.
+        Default 10.
+    snr_threshold : float
+        Voxels with SNR below this value are flagged as low quality in the
+        output quality mask. Default 2.0.
+    """
+
+    min_noise_voxels: int = 10
+    snr_threshold: float = 2.0
+
+
+@dataclass
+class ASLSNRResult:
+    """Result of ASL SNR quality-control computation.
+
+    Attributes
+    ----------
+    snr_map : ParameterMap
+        Voxel-wise SNR map (dimensionless), same spatial shape as input.
+    noise_std : float
+        Estimated noise standard deviation (a.u.) computed from
+        ``noise_mask`` region.
+    mean_snr : float
+        Mean SNR over all brain voxels in the brain mask.
+    quality_mask : NDArray[np.bool_]
+        Boolean mask marking voxels with SNR >= ``params.snr_threshold``
+        as good quality (``True``).
+    """
+
+    snr_map: ParameterMap
+    noise_std: float
+    mean_snr: float
+    quality_mask: "NDArray[np.bool_]"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_snr(
+    cbf_map: "NDArray[np.floating[Any]]",
+    noise_mask: "NDArray[np.bool_]",
+    brain_mask: "NDArray[np.bool_] | None" = None,
+    params: ASLSNRParams | None = None,
+) -> ASLSNRResult:
+    """Compute voxel-wise SNR of an ASL CBF map.
+
+    Estimates noise from a user-supplied background/noise region mask and
+    divides every brain voxel by the noise standard deviation to produce a
+    dimensionless SNR map.  Voxels below ``params.snr_threshold`` are
+    flagged as low quality.
+
+    Parameters
+    ----------
+    cbf_map : NDArray[np.floating]
+        CBF map in mL/100g/min, shape (x, y, z).
+    noise_mask : NDArray[np.bool_]
+        Boolean mask selecting noise-only voxels (e.g., background air
+        outside the head).  Must have the same shape as ``cbf_map``.
+    brain_mask : NDArray[np.bool_] | None
+        Boolean mask selecting brain voxels.  If ``None``, all voxels not
+        in ``noise_mask`` are treated as brain.
+    params : ASLSNRParams | None
+        SNR computation parameters.  Uses defaults if ``None``.
+
+    Returns
+    -------
+    ASLSNRResult
+        SNR map, noise estimate, mean SNR, and quality mask.
+
+    Raises
+    ------
+    DataValidationError
+        If ``cbf_map`` and ``noise_mask`` shapes differ.
+    DataValidationError
+        If fewer than ``params.min_noise_voxels`` noise voxels are found.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from osipy.asl.qc import compute_snr, ASLSNRParams
+    >>> cbf = np.random.rand(16, 16, 8) * 60.0   # mL/100g/min
+    >>> noise = np.zeros((16, 16, 8), dtype=bool)
+    >>> noise[0, :, :] = True                     # top slice = noise
+    >>> result = compute_snr(cbf, noise)
+    >>> print(result.snr_map.units)
+    dimensionless
+
+    References
+    ----------
+    .. [1] Alsop DC et al. (2015). MRM 73(1):102-116.
+       doi:10.1002/mrm.25197
+    .. [2] Xie J et al. (2023). NeuroImage 274:120136.
+       doi:10.1016/j.neuroimage.2023.120136
+    """
+    params = params or ASLSNRParams()
+    xp = get_array_module(cbf_map)
+
+    # ------------------------------------------------------------------
+    # Input validation
+    # ------------------------------------------------------------------
+    if cbf_map.shape != noise_mask.shape:
+        msg = (
+            f"cbf_map shape {cbf_map.shape} must match "
+            f"noise_mask shape {noise_mask.shape}"
+        )
+        raise DataValidationError(msg)
+
+    n_noise = int(xp.sum(noise_mask))
+    if n_noise < params.min_noise_voxels:
+        msg = (
+            f"noise_mask contains only {n_noise} voxels; "
+            f"at least {params.min_noise_voxels} are required for a "
+            f"reliable noise estimate"
+        )
+        raise DataValidationError(msg)
+
+    # ------------------------------------------------------------------
+    # Noise estimation
+    # ------------------------------------------------------------------
+    noise_values = cbf_map[noise_mask]
+    noise_std = float(xp.std(noise_values))
+
+    logger.debug(
+        "Noise estimate: std=%.4f from %d voxels",
+        noise_std,
+        n_noise,
+    )
+
+    # Guard against zero noise (e.g., synthetic data)
+    if noise_std == 0.0:
+        logger.warning(
+            "Noise standard deviation is zero; SNR map will be inf/nan. "
+            "Check that noise_mask selects real background voxels."
+        )
+        noise_std_safe = 1e-10
+    else:
+        noise_std_safe = noise_std
+
+    # ------------------------------------------------------------------
+    # Voxel-wise SNR map
+    # ------------------------------------------------------------------
+    snr = cbf_map / noise_std_safe
+
+    # Zero out noise region in SNR map (not a brain measurement)
+    snr = xp.where(noise_mask, xp.zeros_like(snr), snr)
+
+    # ------------------------------------------------------------------
+    # Brain mask
+    # ------------------------------------------------------------------
+    if brain_mask is None:
+        brain_mask = ~noise_mask
+
+    # ------------------------------------------------------------------
+    # Quality mask — voxels meeting SNR threshold
+    # ------------------------------------------------------------------
+    quality_mask = brain_mask & (snr >= params.snr_threshold)
+
+    # ------------------------------------------------------------------
+    # Summary statistic
+    # ------------------------------------------------------------------
+    brain_snr_values = snr[brain_mask]
+    mean_snr = float(xp.mean(brain_snr_values)) if brain_snr_values.size > 0 else 0.0
+
+    logger.debug("Mean SNR over brain mask: %.2f", mean_snr)
+
+    # ------------------------------------------------------------------
+    # Package result
+    # ------------------------------------------------------------------
+    snr_map = ParameterMap(
+        name="SNR",
+        symbol="SNR",
+        units="dimensionless",
+        values=snr,
+        affine=np.eye(4),
+        quality_mask=quality_mask,
+    )
+
+    return ASLSNRResult(
+        snr_map=snr_map,
+        noise_std=noise_std,
+        mean_snr=mean_snr,
+        quality_mask=quality_mask,
+    )

--- a/osipy/asl/qc/snr.py
+++ b/osipy/asl/qc/snr.py
@@ -149,7 +149,13 @@ def compute_snr(
        doi:10.1016/j.neuroimage.2023.120136
     """
     params = params or ASLSNRParams()
-    xp = get_array_module(cbf_map)
+    xp = get_array_module(cbf_map, noise_mask)
+
+    # Coerce masks to backend-compatible boolean arrays so that NumPy/CuPy
+    # mixed calls do not silently upcast or fail.
+    noise_mask = xp.asarray(noise_mask).astype(bool)
+    if brain_mask is not None:
+        brain_mask = xp.asarray(brain_mask).astype(bool)
 
     # ------------------------------------------------------------------
     # Input validation
@@ -158,6 +164,13 @@ def compute_snr(
         msg = (
             f"cbf_map shape {cbf_map.shape} must match "
             f"noise_mask shape {noise_mask.shape}"
+        )
+        raise DataValidationError(msg)
+
+    if brain_mask is not None and brain_mask.shape != cbf_map.shape:
+        msg = (
+            f"brain_mask shape {brain_mask.shape} does not match "
+            f"cbf_map shape {cbf_map.shape}"
         )
         raise DataValidationError(msg)
 
@@ -174,19 +187,41 @@ def compute_snr(
     # Noise estimation
     # ------------------------------------------------------------------
     noise_values = cbf_map[noise_mask]
-    noise_std = float(xp.std(noise_values))
+
+    # Filter out non-finite values (NaN/Inf) that may originate from upstream
+    # processing, then re-check the minimum voxel count.
+    finite_mask = xp.isfinite(noise_values)
+    noise_values_finite = noise_values[finite_mask]
+    n_noise_finite = int(noise_values_finite.size)
+    if n_noise_finite < params.min_noise_voxels:
+        msg = (
+            f"noise_mask contains {n_noise} voxels, but only "
+            f"{n_noise_finite} are finite; at least "
+            f"{params.min_noise_voxels} finite voxels are required for a "
+            f"reliable noise estimate"
+        )
+        raise DataValidationError(msg)
+
+    noise_std = float(xp.std(noise_values_finite))
+    if not np.isfinite(noise_std):
+        msg = "Noise standard deviation is non-finite; check cbf_map and noise_mask."
+        raise DataValidationError(msg)
 
     logger.debug(
-        "Noise estimate: std=%.4f from %d voxels",
+        "Noise estimate: std=%.4f from %d finite voxels",
         noise_std,
-        n_noise,
+        n_noise_finite,
     )
 
-    # Guard against zero noise (e.g., synthetic data)
+    # Guard against zero noise (e.g., perfectly uniform synthetic data).
+    # We substitute a tiny value so computation continues, but flag all
+    # brain voxels as low-quality via the SNR threshold check.
     if noise_std == 0.0:
         logger.warning(
-            "Noise standard deviation is zero; SNR map will be inf/nan. "
-            "Check that noise_mask selects real background voxels."
+            "Noise standard deviation is zero (substituting 1e-10). "
+            "SNR values will be very large; all voxels may fail the "
+            "quality threshold. Check that noise_mask selects real "
+            "background voxels."
         )
         noise_std_safe = 1e-10
     else:
@@ -197,6 +232,10 @@ def compute_snr(
     # ------------------------------------------------------------------
     snr = cbf_map / noise_std_safe
 
+    # Sanitize non-finite values (NaN/Inf) that can arise if cbf_map itself
+    # contains non-finite entries, consistent with other osipy modules.
+    snr = xp.where(xp.isfinite(snr), snr, xp.zeros_like(snr))
+
     # Zero out noise region in SNR map (not a brain measurement)
     snr = xp.where(noise_mask, xp.zeros_like(snr), snr)
 
@@ -205,6 +244,9 @@ def compute_snr(
     # ------------------------------------------------------------------
     if brain_mask is None:
         brain_mask = ~noise_mask
+    else:
+        # Ensure brain_mask never overlaps the noise region.
+        brain_mask = brain_mask & ~noise_mask
 
     # ------------------------------------------------------------------
     # Quality mask — voxels meeting SNR threshold

--- a/tests/unit/asl/qc/test_snr.py
+++ b/tests/unit/asl/qc/test_snr.py
@@ -1,0 +1,230 @@
+"""Unit tests for ASL QC SNR metric.
+
+Tests for osipy/asl/qc/snr.py.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from osipy.asl.qc.snr import (
+    ASLSNRParams,
+    ASLSNRResult,
+    compute_snr,
+)
+from osipy.common.exceptions import DataValidationError
+from osipy.common.parameter_map import ParameterMap
+
+
+class TestASLSNRParams:
+    """Tests for ASLSNRParams dataclass."""
+
+    def test_default_params(self) -> None:
+        """Test default parameter values."""
+        params = ASLSNRParams()
+        assert params.min_noise_voxels == 10
+        assert params.snr_threshold == 2.0
+
+    def test_custom_params(self) -> None:
+        """Test custom parameter values."""
+        params = ASLSNRParams(min_noise_voxels=20, snr_threshold=5.0)
+        assert params.min_noise_voxels == 20
+        assert params.snr_threshold == 5.0
+
+
+class TestComputeSNR:
+    """Tests for compute_snr function."""
+
+    @pytest.fixture
+    def synthetic_data(self) -> dict:
+        """Create synthetic ASL CBF data with noise region."""
+        np.random.seed(42)
+        shape = (16, 16, 8)
+
+        # Simulate CBF map: brain voxels ~60 mL/100g/min + small noise
+        cbf = np.random.normal(loc=60.0, scale=5.0, size=shape)
+
+        # Noise region: top slice — background with std ~10
+        noise_mask = np.zeros(shape, dtype=bool)
+        noise_mask[0, :, :] = True
+        cbf[noise_mask] = np.random.normal(loc=0.0, scale=10.0, size=noise_mask.sum())
+
+        # Brain mask: everything except noise slice
+        brain_mask = ~noise_mask
+
+        return {
+            "cbf": cbf,
+            "noise_mask": noise_mask,
+            "brain_mask": brain_mask,
+            "shape": shape,
+        }
+
+    def test_returns_asl_snr_result(self, synthetic_data: dict) -> None:
+        """Test that output is ASLSNRResult."""
+        result = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+        )
+        assert isinstance(result, ASLSNRResult)
+
+    def test_snr_map_is_parameter_map(self, synthetic_data: dict) -> None:
+        """Test that snr_map is a ParameterMap with correct metadata."""
+        result = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+        )
+        assert isinstance(result.snr_map, ParameterMap)
+        assert result.snr_map.name == "SNR"
+        assert result.snr_map.units == "dimensionless"
+
+    def test_snr_map_shape_matches_input(self, synthetic_data: dict) -> None:
+        """Test SNR map has same shape as input CBF map."""
+        result = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+        )
+        assert result.snr_map.values.shape == synthetic_data["shape"]
+
+    def test_noise_std_positive(self, synthetic_data: dict) -> None:
+        """Test that noise_std is a positive float."""
+        result = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+        )
+        assert isinstance(result.noise_std, float)
+        assert result.noise_std > 0.0
+
+    def test_mean_snr_positive(self, synthetic_data: dict) -> None:
+        """Test that mean SNR over brain is positive."""
+        result = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+        )
+        assert result.mean_snr > 0.0
+
+    def test_snr_non_negative_in_brain(self, synthetic_data: dict) -> None:
+        """Test SNR values are non-negative in brain region."""
+        result = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+            brain_mask=synthetic_data["brain_mask"],
+        )
+        brain_snr = result.snr_map.values[synthetic_data["brain_mask"]]
+        assert np.all(brain_snr >= 0.0), "SNR should be non-negative in brain"
+
+    def test_noise_region_zeroed_in_snr_map(self, synthetic_data: dict) -> None:
+        """Test that noise region is zeroed out in SNR map."""
+        result = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+        )
+        noise_snr = result.snr_map.values[synthetic_data["noise_mask"]]
+        assert np.all(noise_snr == 0.0), "Noise region should be zero in SNR map"
+
+    def test_quality_mask_shape_matches_input(self, synthetic_data: dict) -> None:
+        """Test quality mask has same shape as input CBF map."""
+        result = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+        )
+        assert result.quality_mask.shape == synthetic_data["shape"]
+
+    def test_quality_mask_bool_dtype(self, synthetic_data: dict) -> None:
+        """Test quality mask is boolean."""
+        result = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+        )
+        assert result.quality_mask.dtype == bool
+
+    def test_snr_increases_with_higher_signal(self) -> None:
+        """Test SNR increases when signal strength increases."""
+        shape = (10, 10, 4)
+        noise_mask = np.zeros(shape, dtype=bool)
+        noise_mask[0, :, :] = True
+
+        # Noise region with fixed std
+        noise = np.random.normal(0.0, 5.0, size=shape)
+        noise[~noise_mask] = 0.0
+
+        # Low signal
+        cbf_low = noise.copy()
+        cbf_low[~noise_mask] = 30.0
+
+        # High signal
+        cbf_high = noise.copy()
+        cbf_high[~noise_mask] = 120.0
+
+        result_low = compute_snr(cbf_low, noise_mask)
+        result_high = compute_snr(cbf_high, noise_mask)
+
+        assert result_high.mean_snr > result_low.mean_snr
+
+    def test_snr_threshold_quality_mask(self, synthetic_data: dict) -> None:
+        """Test that quality_mask respects snr_threshold."""
+        # Very high threshold → most voxels fail
+        params_strict = ASLSNRParams(snr_threshold=1000.0)
+        result_strict = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+            params=params_strict,
+        )
+
+        # Very low threshold → almost all voxels pass
+        params_loose = ASLSNRParams(snr_threshold=0.0)
+        result_loose = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+            params=params_loose,
+        )
+
+        n_pass_strict = int(np.sum(result_strict.quality_mask))
+        n_pass_loose = int(np.sum(result_loose.quality_mask))
+        assert n_pass_strict <= n_pass_loose
+
+    def test_shape_mismatch_raises_error(self) -> None:
+        """Test that mismatched shapes raise DataValidationError."""
+        cbf = np.ones((10, 10, 5))
+        noise_mask = np.zeros((10, 10, 4), dtype=bool)  # wrong z-dimension
+        noise_mask[0, :, :] = True
+
+        with pytest.raises(DataValidationError, match="shape"):
+            compute_snr(cbf, noise_mask)
+
+    def test_too_few_noise_voxels_raises_error(self) -> None:
+        """Test that too few noise voxels raise DataValidationError."""
+        cbf = np.ones((10, 10, 5)) * 60.0
+        noise_mask = np.zeros((10, 10, 5), dtype=bool)
+        noise_mask[0, 0, 0] = True  # only 1 noise voxel
+
+        params = ASLSNRParams(min_noise_voxels=10)
+        with pytest.raises(DataValidationError, match="noise_mask contains only"):
+            compute_snr(cbf, noise_mask, params=params)
+
+    def test_with_explicit_brain_mask(self, synthetic_data: dict) -> None:
+        """Test compute_snr with an explicit brain mask."""
+        result = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+            brain_mask=synthetic_data["brain_mask"],
+        )
+        # Quality mask should only be True inside brain_mask
+        outside_brain = result.quality_mask & ~synthetic_data["brain_mask"]
+        assert not np.any(outside_brain), "Quality mask must not exceed brain_mask"
+
+    def test_without_brain_mask_uses_complement(self, synthetic_data: dict) -> None:
+        """Test that omitting brain_mask uses complement of noise_mask."""
+        result_no_mask = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+            brain_mask=None,
+        )
+        result_with_mask = compute_snr(
+            cbf_map=synthetic_data["cbf"],
+            noise_mask=synthetic_data["noise_mask"],
+            brain_mask=~synthetic_data["noise_mask"],
+        )
+        np.testing.assert_array_equal(
+            result_no_mask.quality_mask, result_with_mask.quality_mask
+        )

--- a/tests/unit/asl/qc/test_snr.py
+++ b/tests/unit/asl/qc/test_snr.py
@@ -192,6 +192,16 @@ class TestComputeSNR:
         with pytest.raises(DataValidationError, match="shape"):
             compute_snr(cbf, noise_mask)
 
+    def test_brain_mask_shape_mismatch_raises_error(self) -> None:
+        """Test that brain_mask with wrong shape raises DataValidationError."""
+        cbf = np.ones((10, 10, 5)) * 60.0
+        noise_mask = np.zeros((10, 10, 5), dtype=bool)
+        noise_mask[0, :, :] = True
+        brain_mask = np.ones((10, 10, 4), dtype=bool)  # wrong shape
+
+        with pytest.raises(DataValidationError, match="brain_mask shape"):
+            compute_snr(cbf, noise_mask, brain_mask=brain_mask)
+
     def test_too_few_noise_voxels_raises_error(self) -> None:
         """Test that too few noise voxels raise DataValidationError."""
         cbf = np.ones((10, 10, 5)) * 60.0
@@ -201,6 +211,39 @@ class TestComputeSNR:
         params = ASLSNRParams(min_noise_voxels=10)
         with pytest.raises(DataValidationError, match="noise_mask contains only"):
             compute_snr(cbf, noise_mask, params=params)
+
+    def test_nan_values_in_noise_region_filtered(self) -> None:
+        """Test that NaN values in noise region are filtered out."""
+        np.random.seed(7)
+        shape = (10, 10, 5)
+        cbf = np.ones(shape) * 60.0
+        noise_mask = np.zeros(shape, dtype=bool)
+        noise_mask[0, :, :] = True  # 100 noise voxels
+
+        # Give finite noise voxels realistic variation (std ≈ 3)
+        cbf[0, :, :] = np.random.normal(loc=0.0, scale=3.0, size=(10, 5))
+        # Inject NaN in half the noise region — should still compute std from rest
+        cbf[0, :5, :] = np.nan
+
+        params = ASLSNRParams(min_noise_voxels=10)
+        result = compute_snr(cbf, noise_mask, params=params)
+        assert np.isfinite(result.noise_std)
+        assert result.noise_std > 0.0
+
+    def test_brain_mask_overlap_with_noise_stripped(self) -> None:
+        """Test that brain_mask overlapping noise_mask is silently clipped."""
+        shape = (10, 10, 5)
+        cbf = np.ones(shape) * 60.0
+        noise_mask = np.zeros(shape, dtype=bool)
+        noise_mask[0, :, :] = True
+
+        # brain_mask deliberately overlaps noise region
+        brain_mask = np.ones(shape, dtype=bool)  # covers everything
+
+        result = compute_snr(cbf, noise_mask, brain_mask=brain_mask)
+
+        # Noise region should not appear as good-quality brain voxels
+        assert not np.any(result.quality_mask[noise_mask])
 
     def test_with_explicit_brain_mask(self, synthetic_data: dict) -> None:
         """Test compute_snr with an explicit brain mask."""
@@ -228,3 +271,4 @@ class TestComputeSNR:
         np.testing.assert_array_equal(
             result_no_mask.quality_mask, result_with_mask.quality_mask
         )
+


### PR DESCRIPTION
## Summary

Part of #116.

Introduces `osipy/asl/qc/` as the foundation for the **Quality Check
Toolbox** (GSoC 2026 project). Adds voxel-wise SNR computation for ASL
CBF maps as the first QC metric.

## Changes

- `osipy/asl/qc/__init__.py` — public package exports
- `osipy/asl/qc/snr.py` — `compute_snr()` with `ASLSNRParams` / `ASLSNRResult`
- `tests/unit/asl/qc/test_snr.py` — 17 passing unit tests

## Why SNR first?

SNR is the most fundamental and universally accepted QC metric for ASL
acquisitions (Alsop et al. 2015). It provides a natural entry point for
the QC Toolbox and establishes the sub-module structure for future metrics.
