### PR TITLE
eat(ivim): add signal reconstruction and RMSE residual map

### DIFF
--- a/osipy/ivim/__init__.py
+++ b/osipy/ivim/__init__.py
@@ -25,6 +25,10 @@ from osipy.ivim.fitting import (
     IVIMFitResult,
     fit_ivim,
 )
+from osipy.ivim.fitting.residuals import (
+    compute_rmse_map,
+    reconstruct_ivim_signal,
+)
 from osipy.ivim.fitting.registry import (
     get_ivim_fitter,
     list_ivim_fitters,
@@ -57,4 +61,7 @@ __all__ = [
     # IVIM fitter registry
     "register_ivim_fitter",
     "register_ivim_model",
+    # Residuals
+    "compute_rmse_map",
+    "reconstruct_ivim_signal",
 ]

--- a/osipy/ivim/fitting/estimators.py
+++ b/osipy/ivim/fitting/estimators.py
@@ -37,6 +37,7 @@ from osipy.common.fitting.least_squares import LevenbergMarquardtFitter
 from osipy.common.parameter_map import ParameterMap
 from osipy.ivim.models.biexponential import IVIMBiexponentialModel
 from osipy.ivim.models.binding import BoundIVIMModel
+from osipy.ivim.fitting.residuals import compute_rmse_map
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -101,6 +102,9 @@ class IVIMFitResult:
         Mask of successfully fitted voxels.
     r_squared : NDArray[np.floating] | None
         Goodness of fit (R^2) map.
+    rmse_map : ParameterMap | None
+        Per-voxel RMSE residual map (a.u.) between observed and
+        reconstructed IVIM signal.  ``None`` if computation fails.
     fitting_stats : dict[str, Any]
         Fitting statistics.
     """
@@ -111,6 +115,7 @@ class IVIMFitResult:
     s0_map: ParameterMap
     quality_mask: "NDArray[np.bool_]"
     r_squared: "NDArray[np.floating[Any]] | None" = None
+    rmse_map: ParameterMap | None = None
     fitting_stats: dict[str, Any] = field(default_factory=dict)
 
 
@@ -235,6 +240,15 @@ def fit_ivim(
         d_map.values, d_star_map.values, f_map.values, quality_mask
     )
 
+    # Compute RMSE residual map
+    try:
+        rmse = compute_rmse_map(
+            signal, d_map, d_star_map, f_map, s0_map, b_values, mask=mask
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("RMSE computation failed; rmse_map will be None.")
+        rmse = None
+
     return IVIMFitResult(
         d_map=d_map,
         d_star_map=d_star_map,
@@ -242,6 +256,7 @@ def fit_ivim(
         s0_map=s0_map,
         quality_mask=quality_mask,
         r_squared=r_squared_values,
+        rmse_map=rmse,
         fitting_stats=fitting_stats,
     )
 

--- a/osipy/ivim/fitting/estimators.py
+++ b/osipy/ivim/fitting/estimators.py
@@ -245,8 +245,12 @@ def fit_ivim(
         rmse = compute_rmse_map(
             signal, d_map, d_star_map, f_map, s0_map, b_values, mask=mask
         )
-    except Exception:  # noqa: BLE001
-        logger.warning("RMSE computation failed; rmse_map will be None.")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "RMSE computation failed; rmse_map will be None. %s",
+            exc,
+            exc_info=True,
+        )
         rmse = None
 
     return IVIMFitResult(

--- a/osipy/ivim/fitting/residuals.py
+++ b/osipy/ivim/fitting/residuals.py
@@ -1,0 +1,200 @@
+"""IVIM signal reconstruction and residual map computation.
+
+This module provides utilities to reconstruct the expected IVIM signal from
+fitted parameter maps and to compute per-voxel RMSE residual maps, enabling
+quantitative assessment of fitting quality beyond the binary quality mask.
+
+Functions
+---------
+reconstruct_ivim_signal
+    Reconstruct IVIM bi-exponential signal from fitted parameter maps.
+compute_rmse_map
+    Compute per-voxel root mean square error between observed and fitted signal.
+
+References
+----------
+.. [1] Le Bihan D et al. (1988). Separation of diffusion and perfusion in
+   intravoxel incoherent motion MR imaging. Radiology 168(2):497-505.
+.. [2] OSIPI CAPLEX, https://osipi.github.io/OSIPI_CAPLEX/
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from osipy.common.backend.array_module import get_array_module
+from osipy.common.parameter_map import ParameterMap
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+def reconstruct_ivim_signal(
+    d_map: ParameterMap,
+    d_star_map: ParameterMap,
+    f_map: ParameterMap,
+    s0_map: ParameterMap,
+    b_values: "NDArray",
+) -> "NDArray":
+    """Reconstruct IVIM bi-exponential signal from fitted parameter maps.
+
+    Computes the predicted signal at each voxel using the IVIM model:
+
+    .. math::
+
+        S(b) = S_0 \\left[ f \\, e^{-b D^*} + (1 - f) \\, e^{-b D} \\right]
+
+    Parameters
+    ----------
+    d_map : ParameterMap
+        Diffusion coefficient (D) map, shape (...,), units mm²/s.
+    d_star_map : ParameterMap
+        Pseudo-diffusion coefficient (D*) map, shape (...,), units mm²/s.
+    f_map : ParameterMap
+        Perfusion fraction (f) map, shape (...,), dimensionless.
+    s0_map : ParameterMap
+        Baseline signal (S0) map, shape (...,), arbitrary units.
+    b_values : NDArray
+        b-values in s/mm², shape (n_b,).
+
+    Returns
+    -------
+    NDArray
+        Reconstructed signal, shape (..., n_b).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from osipy.ivim import fit_ivim, reconstruct_ivim_signal
+    >>> b_values = np.array([0, 50, 100, 200, 400, 800], dtype=float)
+    >>> signal = np.ones((4, 4, 6)) * 1000.0
+    >>> result = fit_ivim(signal, b_values)
+    >>> recon = reconstruct_ivim_signal(
+    ...     result.d_map, result.d_star_map,
+    ...     result.f_map, result.s0_map, b_values,
+    ... )
+    >>> recon.shape
+    (4, 4, 1, 6)
+    """
+    xp = get_array_module(d_map.values)
+
+    d = d_map.values        # (...,)
+    ds = d_star_map.values  # (...,)
+    f = f_map.values        # (...,)
+    s0 = s0_map.values      # (...,)
+
+    # b_values: (n_b,) — cast to same array module
+    b = xp.asarray(b_values)
+
+    # Broadcast: (..., 1) * (n_b,) → (..., n_b)
+    signal = s0[..., xp.newaxis] * (
+        f[..., xp.newaxis] * xp.exp(-b * ds[..., xp.newaxis])
+        + (1.0 - f[..., xp.newaxis]) * xp.exp(-b * d[..., xp.newaxis])
+    )
+    return signal
+
+
+def compute_rmse_map(
+    signal: "NDArray",
+    d_map: ParameterMap,
+    d_star_map: ParameterMap,
+    f_map: ParameterMap,
+    s0_map: ParameterMap,
+    b_values: "NDArray",
+    mask: "NDArray | None" = None,
+) -> ParameterMap:
+    """Compute per-voxel RMSE between observed and fitted IVIM signal.
+
+    Reconstructs the predicted IVIM signal from the fitted parameter maps
+    and computes the root mean square error at each voxel:
+
+    .. math::
+
+        \\text{RMSE}(v) = \\sqrt{\\frac{1}{N_b} \\sum_{i=1}^{N_b}
+        (S_{\\text{obs},i}(v) - S_{\\text{fit},i}(v))^2}
+
+    Voxels outside ``mask`` are set to ``NaN``.
+
+    Parameters
+    ----------
+    signal : NDArray
+        Observed signal, shape (..., n_b).
+    d_map : ParameterMap
+        Fitted D map, shape (...,).
+    d_star_map : ParameterMap
+        Fitted D* map, shape (...,).
+    f_map : ParameterMap
+        Fitted f map, shape (...,).
+    s0_map : ParameterMap
+        Fitted S0 map, shape (...,).
+    b_values : NDArray
+        b-values in s/mm², shape (n_b,).
+    mask : NDArray | None
+        Boolean spatial mask, shape (...,). If ``None``, all voxels
+        are included.
+
+    Returns
+    -------
+    ParameterMap
+        RMSE residual map with:
+        - ``name`` = ``"RMSE"``
+        - ``symbol`` = ``"RMSE"``
+        - ``units`` = ``"a.u."``
+        - ``values`` shape = spatial shape of ``d_map.values``
+        - unmasked voxels set to ``NaN``
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from osipy.ivim import fit_ivim, compute_rmse_map
+    >>> b_values = np.array([0, 50, 100, 200, 400, 800], dtype=float)
+    >>> signal_1d = 1000.0 * (0.9 * np.exp(-b_values * 1e-3)
+    ...                       + 0.1 * np.exp(-b_values * 10e-3))
+    >>> signal = np.broadcast_to(signal_1d, (4, 4, 6)).copy()
+    >>> result = fit_ivim(signal, b_values)
+    >>> rmse = compute_rmse_map(
+    ...     signal, result.d_map, result.d_star_map,
+    ...     result.f_map, result.s0_map, b_values,
+    ... )
+    >>> rmse.values.shape
+    (4, 4, 1)
+    """
+    xp = get_array_module(d_map.values)
+
+    signal_arr = xp.asarray(signal)
+    spatial_shape = d_map.values.shape
+
+    # Reconstruct fitted signal: shape (*spatial_shape, n_b)
+    signal_fit = reconstruct_ivim_signal(
+        d_map, d_star_map, f_map, s0_map, b_values
+    )
+
+    # Reshape observed signal to match (*spatial_shape, n_b) if needed
+    if signal_arr.shape != signal_fit.shape:
+        signal_arr = signal_arr.reshape(signal_fit.shape)
+
+    # Per-voxel RMSE over b-value axis (last axis)
+    residuals = signal_arr - signal_fit
+    rmse_vals = xp.sqrt(xp.mean(residuals ** 2, axis=-1))  # (*spatial_shape,)
+
+    # Apply mask — NaN for unmasked voxels
+    if mask is not None:
+        mask_arr = xp.asarray(mask)
+        # mask may be 2D (x,y) while rmse_vals is (x,y,1) — broadcast
+        if mask_arr.shape != rmse_vals.shape:
+            mask_arr = mask_arr.reshape(
+                mask_arr.shape + (1,) * (rmse_vals.ndim - mask_arr.ndim)
+            )
+        nan_val = xp.full(rmse_vals.shape, xp.nan if hasattr(xp, "nan") else float("nan"))
+        rmse_vals = xp.where(mask_arr, rmse_vals, nan_val)
+
+    return ParameterMap(
+        name="RMSE",
+        symbol="RMSE",
+        units="a.u.",
+        values=rmse_vals,
+        affine=d_map.affine,
+        quality_mask=d_map.quality_mask,
+    )

--- a/osipy/ivim/fitting/residuals.py
+++ b/osipy/ivim/fitting/residuals.py
@@ -20,14 +20,13 @@ References
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-import numpy as np
+from typing import TYPE_CHECKING, Any
 
 from osipy.common.backend.array_module import get_array_module
 from osipy.common.parameter_map import ParameterMap
 
 if TYPE_CHECKING:
+    import numpy as np
     from numpy.typing import NDArray
 
 
@@ -36,8 +35,8 @@ def reconstruct_ivim_signal(
     d_star_map: ParameterMap,
     f_map: ParameterMap,
     s0_map: ParameterMap,
-    b_values: "NDArray",
-) -> "NDArray":
+    b_values: "NDArray[np.floating[Any]]",
+) -> "NDArray[np.floating[Any]]":
     """Reconstruct IVIM bi-exponential signal from fitted parameter maps.
 
     Computes the predicted signal at each voxel using the IVIM model:
@@ -56,12 +55,12 @@ def reconstruct_ivim_signal(
         Perfusion fraction (f) map, shape (...,), dimensionless.
     s0_map : ParameterMap
         Baseline signal (S0) map, shape (...,), arbitrary units.
-    b_values : NDArray
+    b_values : NDArray[np.floating]
         b-values in s/mm², shape (n_b,).
 
     Returns
     -------
-    NDArray
+    NDArray[np.floating]
         Reconstructed signal, shape (..., n_b).
 
     Examples
@@ -97,13 +96,13 @@ def reconstruct_ivim_signal(
 
 
 def compute_rmse_map(
-    signal: "NDArray",
+    signal: "NDArray[np.floating[Any]]",
     d_map: ParameterMap,
     d_star_map: ParameterMap,
     f_map: ParameterMap,
     s0_map: ParameterMap,
-    b_values: "NDArray",
-    mask: "NDArray | None" = None,
+    b_values: "NDArray[np.floating[Any]]",
+    mask: "NDArray[np.bool_] | None" = None,
 ) -> ParameterMap:
     """Compute per-voxel RMSE between observed and fitted IVIM signal.
 
@@ -119,7 +118,7 @@ def compute_rmse_map(
 
     Parameters
     ----------
-    signal : NDArray
+    signal : NDArray[np.floating]
         Observed signal, shape (..., n_b).
     d_map : ParameterMap
         Fitted D map, shape (...,).
@@ -129,9 +128,9 @@ def compute_rmse_map(
         Fitted f map, shape (...,).
     s0_map : ParameterMap
         Fitted S0 map, shape (...,).
-    b_values : NDArray
+    b_values : NDArray[np.floating]
         b-values in s/mm², shape (n_b,).
-    mask : NDArray | None
+    mask : NDArray[np.bool_] | None
         Boolean spatial mask, shape (...,). If ``None``, all voxels
         are included.
 
@@ -144,6 +143,11 @@ def compute_rmse_map(
         - ``units`` = ``"a.u."``
         - ``values`` shape = spatial shape of ``d_map.values``
         - unmasked voxels set to ``NaN``
+
+    Raises
+    ------
+    ValueError
+        If ``signal`` shape is incompatible with the fitted parameter maps.
 
     Examples
     --------
@@ -164,20 +168,34 @@ def compute_rmse_map(
     xp = get_array_module(d_map.values)
 
     signal_arr = xp.asarray(signal)
-    spatial_shape = d_map.values.shape
 
-    # Reconstruct fitted signal: shape (*spatial_shape, n_b)
+    # Reconstruct fitted signal: shape (*spatial_dims, n_b)
     signal_fit = reconstruct_ivim_signal(
         d_map, d_star_map, f_map, s0_map, b_values
     )
 
-    # Reshape observed signal to match (*spatial_shape, n_b) if needed
+    # Validate or fix signal shape
     if signal_arr.shape != signal_fit.shape:
-        signal_arr = signal_arr.reshape(signal_fit.shape)
+        spatial_shape = d_map.values.shape
+        n_b = signal_fit.shape[-1]
+        # Allow singleton-z expansion: maps (x, y, 1), signal (x, y, n_b)
+        if (
+            len(spatial_shape) == 3
+            and spatial_shape[2] == 1
+            and signal_arr.shape == (spatial_shape[0], spatial_shape[1], n_b)
+        ):
+            signal_arr = signal_arr[..., xp.newaxis, :]
+        else:
+            msg = (
+                f"Incompatible signal shape for RMSE computation: "
+                f"got {signal_arr.shape}, expected {signal_fit.shape}. "
+                f"Only omission of a singleton z-dimension is supported."
+            )
+            raise ValueError(msg)
 
     # Per-voxel RMSE over b-value axis (last axis)
     residuals = signal_arr - signal_fit
-    rmse_vals = xp.sqrt(xp.mean(residuals ** 2, axis=-1))  # (*spatial_shape,)
+    rmse_vals = xp.sqrt(xp.mean(residuals ** 2, axis=-1))  # (*spatial_dims,)
 
     # Apply mask — NaN for unmasked voxels
     if mask is not None:
@@ -187,7 +205,7 @@ def compute_rmse_map(
             mask_arr = mask_arr.reshape(
                 mask_arr.shape + (1,) * (rmse_vals.ndim - mask_arr.ndim)
             )
-        nan_val = xp.full(rmse_vals.shape, xp.nan if hasattr(xp, "nan") else float("nan"))
+        nan_val = xp.full(rmse_vals.shape, float("nan"))
         rmse_vals = xp.where(mask_arr, rmse_vals, nan_val)
 
     return ParameterMap(

--- a/tests/unit/ivim/test_ivim_residuals.py
+++ b/tests/unit/ivim/test_ivim_residuals.py
@@ -1,15 +1,12 @@
 """Unit tests for IVIM signal reconstruction and RMSE residual maps."""
 
 import numpy as np
-import pytest
 
 from osipy.ivim import (
-    IVIMFitParams,
     compute_rmse_map,
     fit_ivim,
     reconstruct_ivim_signal,
 )
-from osipy.ivim.fitting.residuals import compute_rmse_map, reconstruct_ivim_signal
 
 
 # ---------------------------------------------------------------------------
@@ -103,9 +100,11 @@ class TestComputeRMSEMap:
 
         # Only check well-fitted voxels
         good = result.quality_mask
-        if good.any():
-            rmse_good = rmse.values[good]
-            assert float(np.nanmax(rmse_good)) < 50.0  # < 5% of S0=1000
+        assert bool(good.any()), (
+            "Expected at least one well-fitted voxel for noise-free synthetic data"
+        )
+        rmse_good = rmse.values[good]
+        assert float(np.nanmax(rmse_good)) < 50.0  # < 5% of S0=1000
 
     def test_rmse_map_shape_matches_spatial(self) -> None:
         """RMSE map spatial shape must match parameter map shapes."""

--- a/tests/unit/ivim/test_ivim_residuals.py
+++ b/tests/unit/ivim/test_ivim_residuals.py
@@ -1,0 +1,192 @@
+"""Unit tests for IVIM signal reconstruction and RMSE residual maps."""
+
+import numpy as np
+import pytest
+
+from osipy.ivim import (
+    IVIMFitParams,
+    compute_rmse_map,
+    fit_ivim,
+    reconstruct_ivim_signal,
+)
+from osipy.ivim.fitting.residuals import compute_rmse_map, reconstruct_ivim_signal
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+B_VALUES = np.array([0, 10, 20, 50, 100, 200, 400, 800], dtype=float)
+S0, D, DS, F = 1000.0, 1.0e-3, 10.0e-3, 0.1
+
+
+def _clean_signal_1d(b: np.ndarray = B_VALUES) -> np.ndarray:
+    """Noise-free IVIM signal for known parameters."""
+    return S0 * ((1 - F) * np.exp(-b * D) + F * np.exp(-b * DS))
+
+
+# ---------------------------------------------------------------------------
+# reconstruct_ivim_signal
+# ---------------------------------------------------------------------------
+
+
+class TestReconstructIVIMSignal:
+    """Tests for reconstruct_ivim_signal()."""
+
+    def test_at_b_zero_equals_s0(self) -> None:
+        """At b=0 the reconstructed signal must equal S0 exactly."""
+        signal_1d = _clean_signal_1d()
+        signal = np.broadcast_to(signal_1d, (3, 3, len(B_VALUES))).copy()
+
+        result = fit_ivim(signal, B_VALUES)
+        recon = reconstruct_ivim_signal(
+            result.d_map, result.d_star_map,
+            result.f_map, result.s0_map,
+            B_VALUES,
+        )
+
+        # b=0 is the first b-value → first element along last axis
+        b0_recon = recon[..., 0]
+        s0_fitted = result.s0_map.values
+        # Reconstructed S(b=0) must match the S0 parameter map
+        np.testing.assert_allclose(b0_recon, s0_fitted, rtol=1e-5)
+
+    def test_signal_shape(self) -> None:
+        """Output shape must be (*spatial_shape, n_b)."""
+        signal_1d = _clean_signal_1d()
+        signal = np.broadcast_to(signal_1d, (4, 4, len(B_VALUES))).copy()
+
+        result = fit_ivim(signal, B_VALUES)
+        recon = reconstruct_ivim_signal(
+            result.d_map, result.d_star_map,
+            result.f_map, result.s0_map,
+            B_VALUES,
+        )
+
+        spatial = result.d_map.values.shape
+        assert recon.shape == spatial + (len(B_VALUES),)
+
+    def test_signal_is_finite(self) -> None:
+        """All reconstructed values must be finite."""
+        signal_1d = _clean_signal_1d()
+        signal = np.broadcast_to(signal_1d, (2, 2, len(B_VALUES))).copy()
+
+        result = fit_ivim(signal, B_VALUES)
+        recon = reconstruct_ivim_signal(
+            result.d_map, result.d_star_map,
+            result.f_map, result.s0_map,
+            B_VALUES,
+        )
+        assert np.all(np.isfinite(recon))
+
+
+# ---------------------------------------------------------------------------
+# compute_rmse_map
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRMSEMap:
+    """Tests for compute_rmse_map()."""
+
+    def test_near_zero_rmse_on_clean_data(self) -> None:
+        """Noise-free signal should give very small RMSE at well-fitted voxels."""
+        signal_1d = _clean_signal_1d()
+        signal = np.broadcast_to(signal_1d, (3, 3, len(B_VALUES))).copy()
+
+        result = fit_ivim(signal, B_VALUES)
+        rmse = compute_rmse_map(
+            signal,
+            result.d_map, result.d_star_map,
+            result.f_map, result.s0_map,
+            B_VALUES,
+        )
+
+        # Only check well-fitted voxels
+        good = result.quality_mask
+        if good.any():
+            rmse_good = rmse.values[good]
+            assert float(np.nanmax(rmse_good)) < 50.0  # < 5% of S0=1000
+
+    def test_rmse_map_shape_matches_spatial(self) -> None:
+        """RMSE map spatial shape must match parameter map shapes."""
+        signal_1d = _clean_signal_1d()
+        signal = np.broadcast_to(signal_1d, (4, 4, len(B_VALUES))).copy()
+
+        result = fit_ivim(signal, B_VALUES)
+        rmse = compute_rmse_map(
+            signal,
+            result.d_map, result.d_star_map,
+            result.f_map, result.s0_map,
+            B_VALUES,
+        )
+
+        spatial = result.d_map.values.shape
+        assert rmse.values.shape == spatial
+
+    def test_rmse_map_metadata(self) -> None:
+        """RMSE ParameterMap must carry correct name, symbol, and units."""
+        signal_1d = _clean_signal_1d()
+        signal = signal_1d.reshape(1, 1, -1)
+
+        result = fit_ivim(signal, B_VALUES)
+        rmse = compute_rmse_map(
+            signal,
+            result.d_map, result.d_star_map,
+            result.f_map, result.s0_map,
+            B_VALUES,
+        )
+
+        assert rmse.name == "RMSE"
+        assert rmse.symbol == "RMSE"
+        assert rmse.units == "a.u."
+
+    def test_unmasked_voxels_are_nan(self) -> None:
+        """Voxels excluded by mask must be NaN in the RMSE map."""
+        signal_1d = _clean_signal_1d()
+        signal = np.broadcast_to(signal_1d, (4, 4, len(B_VALUES))).copy()
+
+        # Mask only the top-left 2×2 block
+        mask = np.zeros((4, 4), dtype=bool)
+        mask[:2, :2] = True
+
+        result = fit_ivim(signal, B_VALUES, mask=mask)
+        rmse = compute_rmse_map(
+            signal,
+            result.d_map, result.d_star_map,
+            result.f_map, result.s0_map,
+            B_VALUES,
+            mask=mask,
+        )
+
+        # Bottom-right region (outside mask) should be NaN
+        outside_vals = rmse.values[2:, 2:].flatten()
+        assert np.all(np.isnan(outside_vals))
+
+
+# ---------------------------------------------------------------------------
+# Integration: fit_ivim returns rmse_map
+# ---------------------------------------------------------------------------
+
+
+class TestFitIVIMIntegration:
+    """Integration tests: rmse_map field in IVIMFitResult."""
+
+    def test_rmse_map_not_none(self) -> None:
+        """fit_ivim() must populate rmse_map on the result."""
+        signal_1d = _clean_signal_1d()
+        signal = np.broadcast_to(signal_1d, (3, 3, len(B_VALUES))).copy()
+
+        result = fit_ivim(signal, B_VALUES)
+
+        assert result.rmse_map is not None
+
+    def test_rmse_map_shape_in_result(self) -> None:
+        """rmse_map from fit_ivim() must have correct spatial shape."""
+        signal_1d = _clean_signal_1d()
+        signal = np.broadcast_to(signal_1d, (4, 4, len(B_VALUES))).copy()
+
+        result = fit_ivim(signal, B_VALUES)
+        spatial = result.d_map.values.shape
+
+        assert result.rmse_map is not None
+        assert result.rmse_map.values.shape == spatial


### PR DESCRIPTION
## Summary

Adds per-voxel RMSE residuals as a quantitative fitting quality metric
for IVIM, complementing the existing binary [quality_mask](cci:1://file:///c:/my%20files/GESOC_2026/osipy/tests/unit/asl/test_buxton.py:178:4-192:44).

## Changes

- [osipy/ivim/fitting/residuals.py](cci:7://file:///c:/my%20files/GESOC_2026/osipy/osipy/ivim/fitting/residuals.py:0:0-0:0) — [reconstruct_ivim_signal()](cci:1://file:///c:/my%20files/GESOC_2026/osipy/osipy/ivim/fitting/residuals.py:33:0-95:17) and
  [compute_rmse_map()](cci:1://file:///c:/my%20files/GESOC_2026/osipy/osipy/ivim/fitting/residuals.py:98:0-199:5) returning a `ParameterMap`
- [osipy/ivim/__init__.py](cci:7://file:///c:/my%20files/GESOC_2026/osipy/osipy/ivim/__init__.py:0:0-0:0) — exports both new functions
- `IVIMFitResult.rmse_map` field (`ParameterMap | None`)
- [fit_ivim()](cci:1://file:///c:/my%20files/GESOC_2026/osipy/osipy/ivim/fitting/estimators.py:121:0-260:5) now computes and returns [rmse_map](cci:1://file:///c:/my%20files/GESOC_2026/osipy/osipy/ivim/fitting/residuals.py:98:0-199:5) automatically
- [tests/unit/ivim/test_ivim_residuals.py](cci:7://file:///c:/my%20files/GESOC_2026/osipy/tests/unit/ivim/test_ivim_residuals.py:0:0-0:0) — 9 passing unit tests

## Why RMSE?

The binary [quality_mask](cci:1://file:///c:/my%20files/GESOC_2026/osipy/tests/unit/asl/test_buxton.py:178:4-192:44) only flags voxels as pass/fail. RMSE gives
a continuous measure of how well the bi-exponential model fits each
voxel, enabling downstream users to threshold by fit quality level.
