### PR TITLE
fix(dce): replace silent except Exception: pass with logged warning

### DIFF
--- a/osipy/dce/fitting.py
+++ b/osipy/dce/fitting.py
@@ -24,6 +24,7 @@ References
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -45,6 +46,9 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
     from osipy.common.fitting.base import BaseFitter
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -419,8 +423,14 @@ def _compute_r_squared_vectorized(
         r2_values = xp.where(ss_tot > 1e-10, 1.0 - ss_res / ss_tot, 0.0)
         r_squared[quality_mask] = r2_values
 
-    except Exception:
-        pass
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "R-squared computation failed; the R\u00b2 map will be zeros. "
+            "This may indicate a model prediction error or incompatible "
+            "array shapes.  %s",
+            exc,
+            exc_info=True,
+        )
 
     return r_squared
 

--- a/osipy/dce/fitting.py
+++ b/osipy/dce/fitting.py
@@ -265,7 +265,7 @@ def _fit_model_impl(
 
     # Perform fitting
     try:
-        param_maps = fitter.fit_image(
+        param_maps: dict[str, ParameterMap] = fitter.fit_image(
             model=bound_model,
             data=ct_4d,
             mask=fit_mask,
@@ -427,7 +427,7 @@ def _compute_r_squared_vectorized(
         logger.warning(
             "R-squared computation failed; the R\u00b2 map will be zeros. "
             "This may indicate a model prediction error or incompatible "
-            "array shapes.  %s",
+            "array shapes. %s",
             exc,
             exc_info=True,
         )

--- a/tests/unit/dce/test_fitting.py
+++ b/tests/unit/dce/test_fitting.py
@@ -286,3 +286,42 @@ class TestDelayFitting:
                 f"Delay should be near 0 for non-delayed data, "
                 f"got {recovered_delay:.2f}"
             )
+
+
+class TestRSquaredWarningOnFailure:
+    """Tests that R-squared failures emit a warning instead of passing silently.
+
+    Regression test for issue #102: ``except Exception: pass`` in
+    ``_compute_r_squared_vectorized`` silently swallowed all errors,
+    making it impossible to diagnose fitting problems.
+    """
+
+    def test_r_squared_failure_emits_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A model prediction error must log a WARNING, not pass silently."""
+        import logging
+        from unittest.mock import MagicMock
+
+        from osipy.dce.fitting import _compute_r_squared_vectorized
+
+        xp = np
+        ct_4d = xp.ones((2, 2, 1, 10))
+        quality_mask = xp.ones((2, 2, 1), dtype=bool)
+        param_maps: dict = {}
+
+        # A bound_model whose predict_array_batch raises
+        bound_model = MagicMock()
+        bound_model.parameters = []
+        bound_model.predict_array_batch.side_effect = RuntimeError("simulated failure")
+
+        with caplog.at_level(logging.WARNING, logger="osipy.dce.fitting"):
+            result = _compute_r_squared_vectorized(
+                ct_4d, bound_model, param_maps, quality_mask, xp
+            )
+
+        assert "R-squared computation failed" in caplog.text, (
+            "Expected a WARNING about R-squared failure but none was emitted"
+        )
+        assert np.all(result == 0.0), (
+            "R-squared map should be zeros when computation fails"
+        )
+

--- a/tests/unit/dce/test_fitting.py
+++ b/tests/unit/dce/test_fitting.py
@@ -306,7 +306,7 @@ class TestRSquaredWarningOnFailure:
         xp = np
         ct_4d = xp.ones((2, 2, 1, 10))
         quality_mask = xp.ones((2, 2, 1), dtype=bool)
-        param_maps: dict = {}
+        param_maps: dict[str, ParameterMap] = {}
 
         # A bound_model whose predict_array_batch raises
         bound_model = MagicMock()


### PR DESCRIPTION
Fixes #102.

While reviewing the codebase I noticed that [_compute_r_squared_vectorized()](cci:1://file:///c:/my%20files/GESOC_2026/osipy/osipy/dce/fitting.py:354:0-434:20) 
in [osipy/dce/fitting.py](cci:7://file:///c:/my%20files/GESOC_2026/osipy/osipy/dce/fitting.py:0:0-0:0) had a bare `except Exception: pass` block 
(lines 403–419). This means any error during R-squared computation is 
completely hidden — users get a zero R² map with no indication that 
something went wrong, which makes debugging very difficult.

This PR fixes that by:

- Adding a module-level logger to [dce/fitting.py](cci:7://file:///c:/my%20files/GESOC_2026/osipy/osipy/dce/fitting.py:0:0-0:0)
- Replacing the silent `pass` with a proper `WARNING` log that includes 
  the exception message and full stack trace

I also added a regression test ([TestRSquaredWarningOnFailure](cci:2://file:///c:/my%20files/GESOC_2026/osipy/tests/unit/dce/test_fitting.py:290:0-325:9)) to 
ensure this behavior is preserved going forward. All 9 tests pass.

Happy to adjust the log level or message format if needed.
