### PR TITLE
Refactor config dumps to use Pydantic model introspection

### DIFF
--- a/Refactor config dumps to use Pydantic model introspection
+++ b/Refactor config dumps to use Pydantic model introspection
@@ -1,0 +1,3 @@
+Summary
+
+This PR replaces the current hard-coded YAML templates used in dump_defaults() with an auto-generated YAML output derived directly from the project’s Pydantic configuration models. This ensures that all config fields are always up-to-date with the underlying model definitions and eliminates the risk of drift between template strings and actual config fields.


### PR DESCRIPTION
Summary

This PR replaces the current hard-coded YAML templates used in dump_defaults() with an auto-generated YAML output derived directly from the project’s Pydantic configuration models. This ensures that all config fields are always up-to-date with the underlying model definitions and eliminates the risk of drift between template strings and actual config fields.
CLOSES #129 
Motivation

The existing implementation of dump_defaults() in osipy/cli/config.py returns static YAML templates stored in the _DEFAULT_TEMPLATES dictionary. These templates have already diverged from the true set of config fields — for example, fields such as fit_delay and delay_bounds are defined in the Pydantic models but missing from the templates. Manual maintenance of these templates is error-prone and unsustainable as the project evolves.

What Changed
Removed: The `_DEFAULT_TEMPLATES` dictionary of hard-coded YAML strings.
Added: A new YAML generator that introspects `Pydantic models using:
model_json_schema()`
Field metadata such as defaults, types, and descriptions
Improved:` Human-readability of generated YAML` by grouping fields by section and preserving comments from model Field(description=...).
Ensured: All config classes now appear accurately in the output, automatically reflecting any additions or changes.


## 📌 Summary

This PR improves YAML generation.

## 🧪 Example Output

<pre>
key: value
</pre>

## 📂 Changes

- Updated config logic
- Removed static templates


Example Output

Here is a snippet of the new generated YAML for a config class (illustrative example):
```YAML
# ExampleConfig
field1: 10          # description of field1
field2: "default"   # description of field2
nested:
  subfield1: true   # nested field description```

Benefits
Consistency: Config dumps always match the actual config models.
Maintainability: No manual editing of YAML templates.
Extensibility: New config fields automatically included without additional work.
Clarity: Users see accurate, commented config defaults.


esting

To verify correctness:

Run `dump_defaults() `and confirm YAML output includes all fields from each config model.
Ensure human-readable comments reflect model descriptions.
Compare output with legacy template to confirm no missing sections.